### PR TITLE
Allow PlaidLink component customization and export openLink

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { NativeModules, Platform, TouchableOpacity } from 'react-native';
 
-const openLink = async ({ onExit, onSuccess, ...serializable }) => {
+export const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   if (Platform.OS === 'android') {
     const constants = NativeModules.PlaidAndroid.getConstants();
     NativeModules.PlaidAndroid.startLinkActivityForResult(
@@ -51,11 +51,11 @@ const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   }
 };
 
-const handlePress = (linkProps) => {
+const handlePress = (linkProps, componentProps) => {
   openLink(linkProps);
   if (componentProps && componentProps.onPress) {
     componentProps.onPress();
-  };
+  }
 };
 
 export const PlaidLink = ({
@@ -67,7 +67,7 @@ export const PlaidLink = ({
   return (
     <Component
       {...componentProps}
-      onPress={() => handlePress(linkProps)}
+      onPress={() => handlePress(linkProps, componentProps)}
     />
   );
 };

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { NativeModules, Platform, TouchableOpacity, View } from 'react-native';
+import { NativeModules, Platform, TouchableOpacity } from 'react-native';
 
 const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   if (Platform.OS === 'android') {
@@ -51,22 +51,24 @@ const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   }
 };
 
+const handlePress = (linkProps) => {
+  openLink(linkProps);
+  if (componentProps && componentProps.onPress) {
+    componentProps.onPress();
+  };
+};
+
 export const PlaidLink = ({
-  children,
-  style,
-  accessibilityLabel,
-  testID,
+  component,
+  componentProps,
   ...linkProps
 }) => {
+  const Component = component;
   return (
-      <TouchableOpacity
-        style={style}
-        onPress={() => openLink(linkProps)}
-        accessibilityLabel={accessibilityLabel}
-        testID={testID}
-      >
-        {children}
-      </TouchableOpacity>
+    <Component
+      {...componentProps}
+      onPress={() => handlePress(linkProps)}
+    />
   );
 };
 
@@ -129,6 +131,16 @@ PlaidLink.propTypes = {
   // Specify a webhook to associate with a user.
   webhook: PropTypes.string,
 
+  // Underlying component to render
+  component: PropTypes.func,
+
+  // Props for underlying component
+  componentProps: PropTypes.object,
+
   // Note: onEvent is omitted here, to handle onEvent callbacks refer to
   // the documentation here: https://github.com/plaid/react-native-plaid-link-sdk#to-receive-onevent-callbacks
+};
+
+PlaidLink.defaultProps = {
+  component: TouchableOpacity,
 };

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, NativeModules, Platform, View } from 'react-native';
+import { NativeModules, Platform, TouchableOpacity, View } from 'react-native';
 
 const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   if (Platform.OS === 'android') {
@@ -53,24 +53,20 @@ const openLink = async ({ onExit, onSuccess, ...serializable }) => {
 
 export const PlaidLink = ({
   children,
-  className,
-  title,
+  style,
   accessibilityLabel,
-  color,
+  testID,
   ...linkProps
 }) => {
   return (
-    <View>
-      <Button
-        className={className}
+      <TouchableOpacity
+        style={style}
         onPress={() => openLink(linkProps)}
-        title={title}
         accessibilityLabel={accessibilityLabel}
-        color={color}
+        testID={testID}
       >
         {children}
-      </Button>
-    </View>
+      </TouchableOpacity>
   );
 };
 
@@ -107,9 +103,6 @@ PlaidLink.propTypes = {
   publicKey: PropTypes.string.isRequired,
 
   // Optional props
-
-  // Button class name as a string.
-  className: PropTypes.string,
 
   // A list of Plaid-supported country codes using the ISO-3166-1 alpha-2
   // country code standard.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
-import { PlaidLink } from './PlaidLink';
+import { openLink, PlaidLink } from './PlaidLink';
 
 export default PlaidLink;
+export { openLink };


### PR DESCRIPTION
This PR allows the developers to customize the CTA that opens PlaidLink modal to match each app UI/UX.

Specifically:
- Changed the component to be a `TouchableOpacity`
- Removed `className` prop since is not valid for React Native (it only works for ReactJS) and added a `style` prop instead
- Added `testID` prop to be passed same as `accessibilityLabel`

By doing this you can instance the component as follows:

```
<PlaidLink
  publicKey='<# Your Public Key #>'
  clientName='<# Your Client Name #>'
  env='<# Environment #>'  // 'sandbox' or 'development' or 'production'
  onSuccess={e => console.log('success: ', e)}
  product={['<# Product #>']}
  style={styles.button}>
  <Text style={styles.text}> Add Account </Text>
</PlaidLink>
```