### PR TITLE
Expose close() method to be able to close the modal programatically.

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -191,6 +191,11 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)callback) {
     }
 }
 
+RCT_EXPORT_METHOD(close) {
+    __weak typeof(self) weakSelf = self;
+    [weakSelf dismissLinkViewController];
+}
+
 - (void)dismissLinkViewController {
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     self.presentingViewController = nil;


### PR DESCRIPTION
According to [docs](https://plaid.com/docs/#exit-function) for `exit()` function 

> exit() works on desktop and mobile but isn’t supported for WebView integrations. To exit Link in a WebView, you must programmatically close the iOS or Android WebView.

This PR enables this ability by exposing a `close` method to React Native module