### PR TITLE
defaults to FullScreen mode

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -212,10 +212,7 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
                                                                               delegate:self.linkViewDelegate];
     }
     
-    // self.linkViewController.modalPresentationStyle = UIModalPresentationStyle.UIModalPresentationFullScreen;
-    // UIModalPresentationFullScreen = 0. I don't know what to import to get UIModalPresentationStyle enum
-    self.linkViewController.modalPresentationStyle = 0;
-
+    self.linkViewController.modalPresentationStyle = UIModalPresentationFullScreen;
 }
 
 RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)callback) {

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -211,6 +211,11 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
         self.linkViewController = [[PLKPlaidLinkViewController alloc] initWithConfiguration:linkConfiguration
                                                                               delegate:self.linkViewDelegate];
     }
+    
+    // self.linkViewController.modalPresentationStyle = UIModalPresentationStyle.UIModalPresentationFullScreen;
+    // UIModalPresentationFullScreen = 0. I don't know what to import to get UIModalPresentationStyle enum
+    self.linkViewController.modalPresentationStyle = 0;
+
 }
 
 RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)callback) {


### PR DESCRIPTION
fixes #57 

better code would be something like:

```
self.linkViewController.modalPresentationStyle = UIModalPresentationStyle.UIModalPresentationFullScreen;
```

but i don't know objective-c and ios that much so i dont know what header to import to get the `UIModalPresentationStyle`

hardcoding to `0` since `UIModalPresentationStyle` is `0` in the enum. see:

https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationfullscreen?language=objc