### PR TITLE
Added oauth support for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,9 @@ allprojects {
         }
         google()
         jcenter()
+        maven {
+            url "https://artifactory.plaid.io/artifactory/link-sdk"
+        }
     }
 }
 
@@ -55,7 +58,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.plaid.link:sdk-core:1.0.0'
+    implementation 'com.plaid.link:sdk-core:1.0.2-ZDS-Debugging'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
 }

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -44,6 +44,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     private const val LANGUAGE = "language"
     private const val ENV = "env"
     private const val LINK_CUSTOMIZATION_NAME = "linkCustomizationName"
+    private const val OAUTH_NONCE = "oauthNonce"
     private const val PUBLIC_TOKEN = "publicToken"
     private const val USER_EMAIL = "userEmailAddress"
     private const val USER_NAME = "userLegalName"
@@ -141,6 +142,12 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
       if (obj.has(LINK_CUSTOMIZATION_NAME)) {
         if (!TextUtils.isEmpty(obj.getString(LINK_CUSTOMIZATION_NAME))) {
           builder.linkCustomizationName(obj.getString(LINK_CUSTOMIZATION_NAME))
+        }
+      }
+
+      if (obj.has(OAUTH_NONCE)) {
+        if (!TextUtils.isEmpty(obj.getString(OAUTH_NONCE))) {
+          builder.oauthNonce(obj.getString(OAUTH_NONCE))
         }
       }
 


### PR DESCRIPTION
The oauthNonce parameter was not being passed from the PlaidModule into the Android SDK.  With this parameter passed in, we will now have oauth support on Android.