### PR TITLE
added check to ignore result if onActivityResult is not triggered by Plaid

### DIFF
--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -244,7 +244,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
         this.callback?.invoke(result)
       } catch(t: Throwable) { 
         // log error
-        println("error in plaid module" + t)
+        Plog.e("error in plaid module" + t.stackTrace)
       }
     }
   }

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -239,7 +239,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
         if (data.extras != null) {
           result.putMap(DATA, Arguments.makeNativeMap(data.extras))
         }
-        println("callback invoked")
+        Plog.d("callback invoked")
         print(result)
         this.callback?.invoke(result)
       } catch(t: Throwable) { 

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -205,8 +205,13 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     data: Intent?
   ) {
     val result = WritableNativeMap()
+    val PLAID_RESULT_CODES = arrayOf(Plaid.RESULT_SUCCESS, Plaid.RESULT_CANCELLED, Plaid.RESULT_EXIT)
 
     result.putInt(RESULT_CODE, resultCode)
+    if(!PLAID_RESULT_CODES.contains(resultCode)) {
+      Plog.w("ignoring result")
+      return
+    }
 
     // This should not happen but if it does we have no data to return
     if (data == null) {
@@ -230,10 +235,17 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
       }
       this.callback?.invoke(result)
     } else {
-      if (data.extras != null) {
-        result.putMap(DATA, Arguments.makeNativeMap(data.extras))
+      try {
+        if (data.extras != null) {
+          result.putMap(DATA, Arguments.makeNativeMap(data.extras))
+        }
+        println("callback invoked")
+        print(result)
+        this.callback?.invoke(result)
+      } catch(t: Throwable) { 
+        // log error
+        println("error in plaid module" + t)
       }
-      this.callback?.invoke(result)
     }
   }
 


### PR DESCRIPTION
onActivityResult was being triggered from Intents not started by Plaid. I have added a check to ignore invoking the callback function if the resultCode does not belong to Plaid's resultCodes.