### PR TITLE
Expose dismissLink method.

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -50,6 +50,12 @@ export const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   }
 };
 
+export const dismissLink = () => {
+  if (Platform.OS === 'ios') {
+    NativeModules.RNLinksdk.dismiss();
+  }
+};
+
 const handlePress = (linkProps, componentProps) => {
   openLink(linkProps);
   if (componentProps && componentProps.onPress) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { openLink, PlaidLink } from './PlaidLink';
+import { openLink, dismissLink, PlaidLink } from './PlaidLink';
 
 export default PlaidLink;
-export { openLink };
+export { openLink, dismissLink };

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -224,6 +224,10 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)callback) {
     }
 }
 
+RCT_EXPORT_METHOD(dismiss) {
+    [self dismissLinkViewController];
+}
+
 - (void)dismissLinkViewController {
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     self.presentingViewController = nil;


### PR DESCRIPTION
This PR allows OAuth flows on iOS to dismiss any existing link view controller when re-opening plaid after an applink callback.

Fixes #63 