### PR TITLE
Add support for account subtype filtering

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -114,8 +114,12 @@ PlaidLink.propTypes = {
 
   // Optional props
 
-  // You can configure Link to return only the accounts that are a
-  // checking or savings account subtype
+  // You can configure Link to return only the accounts that
+  // match a given type and subtype
+  //
+  // This object is a nonempty Map<account type, Array<account subtype>>
+  // where account type and account subtype are strings
+  //
   // see https://plaid.com/docs/#auth-filtering-institutions-in-link
   // and https://plaid.com/docs/#filtering-institutions-in-link
   accountSubtypes: PropTypes.object,

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -122,7 +122,11 @@ PlaidLink.propTypes = {
   //
   // see https://plaid.com/docs/#auth-filtering-institutions-in-link
   // and https://plaid.com/docs/#filtering-institutions-in-link
-  accountSubtypes: PropTypes.object,
+  accountSubtypes: PropTypes.shape({
+    credit: PropTypes.arrayOf(PropTypes.string),
+    depository: PropTypes.arrayOf(PropTypes.string),
+    loan: PropTypes.arrayOf(PropTypes.string),
+  }),
 
   // A list of Plaid-supported country codes using the ISO-3166-1 alpha-2
   // country code standard.

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -114,6 +114,12 @@ PlaidLink.propTypes = {
 
   // Optional props
 
+  // You can configure Link to return only the accounts that are a
+  // checking or savings account subtype
+  // see https://plaid.com/docs/#auth-filtering-institutions-in-link
+  // and https://plaid.com/docs/#filtering-institutions-in-link
+  accountSubtypes: PropTypes.object,
+
   // A list of Plaid-supported country codes using the ISO-3166-1 alpha-2
   // country code standard.
   countryCodes: PropTypes.arrayOf(PropTypes.string),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.plaid.link:sdk-core:1.1.0'
+    implementation 'com.plaid.link:sdk-core:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.plaid.link:sdk-core:1.0.3
+    implementation 'com.plaid.link:sdk-core:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -17,6 +17,7 @@ static NSString* const kRNLinkKitConfigSelectAccountKey = @"selectAccount";
 static NSString* const kRNLinkKitConfigUserLegalNameKey = @"userLegalName";
 static NSString* const kRNLinkKitConfigUserEmailAddressKey = @"userEmailAddress";
 static NSString* const kRNLinkKitConfigUserPhoneNumberKey = @"userPhoneNumber";
+static NSString* const kRNLinkKitConfigAccountSubtypes = @"accountSubtypes";
 static NSString* const kRNLinkKitConfigCountryCodesKey = @"countryCodes";
 static NSString* const kRNLinkKitConfigLanguageKey = @"language";
 static NSString* const kRNLinkKitConfigInstitutionKey = @"institution";
@@ -101,6 +102,7 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
     NSString *oauthRedirectUri = [RCTConvert NSString:configuration[kRNLinkKitConfigOAuthRedirectUriKey]];
     NSString *oauthNonce = [RCTConvert NSString:configuration[kRNLinkKitConfigOAuthNonceKey]];
     NSString *oauthStateId = [RCTConvert NSString:configuration[kRNLinkKitConfigOAuthStateIdKey]];
+    NSObject<NSDictionary<NSString, NSArray<NSString*>>> *accountSubtypes = [RCTConvert NSStringArray:configuration[kRNLinkKitConfigAccountSubtypes]];
     NSArray<NSString*> *countryCodes = [RCTConvert NSStringArray:configuration[kRNLinkKitConfigCountryCodesKey]];
     NSString *language = [RCTConvert NSString:configuration[kRNLinkKitConfigLanguageKey]];
     BOOL selectAccount = [RCTConvert BOOL:configuration[kRNLinkKitConfigSelectAccountKey]];
@@ -140,6 +142,9 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
     }
     if ([oauthNonce length] > 0) {
         linkConfiguration.oauthNonce = oauthNonce;
+    }
+    if ([accountSubtypes count] > 0) {
+       linkConfiguration.accountSubtypes = accountSubtypes;
     }
     if ([countryCodes count] > 0) {
        linkConfiguration.countryCodes = countryCodes;


### PR DESCRIPTION
Expose a property on the PlaidLink component for account subtype filtering.  In iOS this property is directly consumed.  On Android this property is not exposed yet so we use extra params until the next sdk release.