### PR TITLE
Update to Android 1.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -58,7 +58,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.plaid.link:sdk-core:1.2.1'
+    implementation 'com.plaid.link:sdk-core:1.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Plaid Technologies, Inc. <support@plaid.com>
+#
+
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx1536m
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+
+org.gradle.parallel=true
+org.gradle.configureondemand=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -159,7 +159,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
 
       if (obj.has(PUBLIC_TOKEN)) {
         if (!TextUtils.isEmpty(obj.getString(PUBLIC_TOKEN))) {
-          builder.publicToken(obj.getString(PUBLIC_TOKEN))
+          builder.token(obj.getString(PUBLIC_TOKEN))
         }
       }
 


### PR DESCRIPTION
Updates dependencies for Android 1.3.0.   Also addresses the 1.3.0 breaking change which renamed `LinkConfiguration.publicToken` to `LinkConfiguration.token` internally.  Externally, we still expose `publicToken`