### PR TITLE
RN: Change Android public_token to token

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.plaid.link:sdk-core:1.2.1'
+    implementation 'com.plaid.link:sdk-core:1.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
 }

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -46,7 +46,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     private const val ENV = "env"
     private const val LINK_CUSTOMIZATION_NAME = "linkCustomizationName"
     private const val OAUTH_NONCE = "oauthNonce"
-    private const val PUBLIC_TOKEN = "publicToken"
+    private const val TOKEN = "token"
     private const val USER_EMAIL = "userEmailAddress"
     private const val USER_NAME = "userLegalName"
     private const val USER_PHONE = "userPhoneNumber"
@@ -128,10 +128,8 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
         }
       }
 
-      if (obj.has(LANGUAGE)) {
-        if (!TextUtils.isEmpty(obj.getString(LANGUAGE))) {
-          builder.language(obj.getString(LANGUAGE))
-        }
+      maybeGetStringField(obj, LANGUAGE)?.let {
+        builder.language(it)
       }
 
       if (obj.has(ENV)) {
@@ -145,46 +143,32 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
         }
       }
 
-      if (obj.has(LINK_CUSTOMIZATION_NAME)) {
-        if (!TextUtils.isEmpty(obj.getString(LINK_CUSTOMIZATION_NAME))) {
-          builder.linkCustomizationName(obj.getString(LINK_CUSTOMIZATION_NAME))
-        }
+      maybeGetStringField(obj, LINK_CUSTOMIZATION_NAME)?.let {
+        builder.linkCustomizationName(it)
       }
 
-      if (obj.has(OAUTH_NONCE)) {
-        if (!TextUtils.isEmpty(obj.getString(OAUTH_NONCE))) {
-          builder.oauthNonce(obj.getString(OAUTH_NONCE))
-        }
+      maybeGetStringField(obj, OAUTH_NONCE)?.let {
+        builder.oauthNonce(it)
       }
 
-      if (obj.has(PUBLIC_TOKEN)) {
-        if (!TextUtils.isEmpty(obj.getString(PUBLIC_TOKEN))) {
-          builder.publicToken(obj.getString(PUBLIC_TOKEN))
-        }
+      maybeGetStringField(obj, TOKEN)?.let {
+        builder.token(it)
       }
 
-      if (obj.has(USER_EMAIL)) {
-        if (!TextUtils.isEmpty(obj.getString(USER_EMAIL))) {
-          builder.userEmailAddress(obj.getString(USER_EMAIL))
-        }
+      maybeGetStringField(obj, USER_EMAIL)?.let {
+        builder.userEmailAddress(it)
       }
 
-      if (obj.has(USER_NAME)) {
-        if (!TextUtils.isEmpty(obj.getString(USER_NAME))) {
-          builder.userLegalName(obj.getString(USER_NAME))
-        }
+      maybeGetStringField(obj, USER_NAME)?.let {
+        builder.userLegalName(it)
       }
 
-      if (obj.has(USER_PHONE)) {
-        if (!TextUtils.isEmpty(obj.getString(USER_PHONE))) {
-          builder.userPhoneNumber(obj.getString(USER_PHONE))
-        }
+      maybeGetStringField(obj, USER_PHONE)?.let {
+        builder.userPhoneNumber(it)
       }
 
-      if (obj.has(WEBHOOK)) {
-        if (!TextUtils.isEmpty(obj.getString(WEBHOOK))) {
-          builder.webhook(obj.getString(WEBHOOK))
-        }
+      maybeGetStringField(obj, WEBHOOK)?.let {
+        builder.webhook(it)
       }
 
       if (extrasMap.isNotEmpty()) {
@@ -205,7 +189,13 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
       result.putString(DATA, snakeCaseGson.toJson(plaidErrorFromException(ex)))
       this.callback?.invoke(result)
     }
+  }
 
+  private fun maybeGetStringField(obj: JSONObject, fieldName: String): String? {
+    if (obj.has(fieldName) && !TextUtils.isEmpty(obj.getString(fieldName))) {
+      return obj.getString(fieldName)
+    }
+    return null
   }
 
   override fun onActivityResult(


### PR DESCRIPTION
Right now users have to pass in different fields for Android and iOS: https://github.com/plaid/react-native-plaid-link-sdk/pull/111/files
Ideally they pass `token` to both platforms, and with Android Link SDK using `token` in 1.3.0, we can.

Also added change to simplify passing string fields to LinkConfiguration:
Not really saving that many lines, but at least reducing potential future errors where we copy and paste that block and forget to change fieldName in each part.

💚 How did you test it?
Ran LinkSdkSample