### PR TITLE
Update component PropTypes

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -203,7 +203,7 @@ PlaidLink.propTypes = {
   oauthStateId: PropTypes.string,
 
   // Underlying component to render
-  component: PropTypes.func,
+  component: PropTypes.elementType,
 
   // Props for underlying component
   componentProps: PropTypes.object,


### PR DESCRIPTION
Update component PropTypes to support all components (native components, stateless components, stateful components, forward refs, context providers/consumers).

`elementType` was Introduced in `PropTypes: 15.7.0` in this  [PR](https://github.com/facebook/prop-types/pull/211)