### PR TITLE
Update  to include okhttp3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dependencies {
     ...
     implementation project(':react-native-plaid-link-sdk')
     implementation 'com.plaid.link:sdk-core:<insert latest version>'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.+'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:<insert at least version 4.x>'
 ```
 
 5. Go to `android/settings.gradle`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ dependencies {
     ...
     implementation project(':react-native-plaid-link-sdk')
     implementation 'com.plaid.link:sdk-core:<insert latest version>'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.+'
 ```
 
 5. Go to `android/settings.gradle`


### PR DESCRIPTION
We need to include the okhttp3 version 4.x because RN hardcodes 3.12.1 while the internal Android sdk uses 4.2.1

Adding this line will fix the errors while we investigate a long-term solution.