### PR TITLE
support server-side config changes for Android and iOS

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -78,16 +78,34 @@ export const PlaidLink = ({
 PlaidLink.propTypes = {
   // Required props
 
-  // Displayed once a user has successfully linked their account
-  clientName: PropTypes.string.isRequired,
-
-  // The Plaid API environment on which to create user accounts.
-  env: PropTypes.oneOf(['development', 'sandbox', 'production']).isRequired,
-
   // A function that is called when a user has successfully onboarded their
   // account. The function should expect two arguments, the public_key and a
   // metadata object.
   onSuccess: PropTypes.func.isRequired,
+
+  // Optional props
+
+  // The public_key associated with your account; available from
+  // the Plaid dashboard (https://dashboard.plaid.com).
+  // 
+  // [DEPRECATED] - instead, pass a Link token into the token field.
+  // Create a Link token with the /link/token/create endpoint.
+  publicKey: props => {
+    if (!props.publicKey && !props.token) {
+      return new Error(`One of props 'publicKey' or 'token' is required`);
+    }
+    if (typeof props.publicKey !== 'string') {
+      return new Error(
+        `Invalid prop 'publicKey': Expected string instead of ${typeof props.publicKey}`,
+      );
+    }
+  },
+
+  // Displayed once a user has successfully linked their account
+  clientName: PropTypes.string,
+
+  // The Plaid API environment on which to create user accounts.
+  env: PropTypes.oneOf(['development', 'sandbox', 'production']),
 
   // The Plaid product(s) you wish to use, an array containing some of
   // auth, identity, income, transactions, assets, liabilities, investments.
@@ -101,23 +119,7 @@ PlaidLink.propTypes = {
       'liabilities',
       'investments',
     ]),
-  ).isRequired,
-
-  // Optional props
-
-  // The public_key associated with your account; available from
-  // the Plaid dashboard (https://dashboard.plaid.com).
-  // Either publicKey or token is required.
-  publicKey: props => {
-    if (!props.publicKey && !props.token) {
-      return new Error(`One of props 'publicKey' or 'token' is required`);
-    }
-    if (typeof props.publicKey !== 'string') {
-      return new Error(
-        `Invalid prop 'publicKey': Expected string instead of ${typeof props.publicKey}`,
-      );
-    }
-  },
+  ),
 
   // You can configure Link to return only the accounts that
   // match a given type and subtype
@@ -146,11 +148,8 @@ PlaidLink.propTypes = {
   // A function that is called when a user has specifically exited Link flow.
   onExit: PropTypes.func,
 
-  // Specify an existing user's public token to launch Link in update mode.
-  // This will cause Link to open directly to the authentication step for
-  // that user's institution.
-  // Pass an item_add_token to launch Link in regular mode without a public_key.
-  // Either publicKey or token is required.
+  // Specify a Link token to launch link. To create a Link token, use the
+  // /link/token/create endpoint.
   token: PropTypes.string,
 
   // Specify a user to enable all Auth features. Reach out to your

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -94,7 +94,7 @@ PlaidLink.propTypes = {
     if (!props.publicKey && !props.token) {
       return new Error(`One of props 'publicKey' or 'token' is required`);
     }
-    if (typeof props.publicKey !== 'string') {
+    if (typeof props.publicKey !== 'string' && !props.token) {
       return new Error(
         `Invalid prop 'publicKey': Expected string instead of ${typeof props.publicKey}`,
       );

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -99,6 +99,7 @@ PlaidLink.propTypes = {
         `Invalid prop 'publicKey': Expected string instead of ${typeof props.publicKey}`,
       );
     }
+    console.log("The public_key is being deprecated. Learn how to upgrade to link_tokens at https://plaid.com/docs/#create-link-token");
   },
 
   // Displayed once a user has successfully linked their account

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -78,6 +78,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
   fun getLinkConfiguration(data: String): LinkConfiguration {
     val obj = JSONObject(data)
     val extrasMap = mutableMapOf<String, String>()
+    val logLevel = LinkLogLevel.ASSERT
 
     // If we're initializing with a Link token, we will not use or
     // accept many of the client-side configs.
@@ -86,6 +87,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
       if (it.startsWith(LINK_TOKEN_PREFIX)) {
         val builder = LinkTokenConfiguration.Builder()
           .token(obj.getString(TOKEN))
+          .logLevel(logLevel)
 
         if (extrasMap.isNotEmpty()) {
           builder.extraParams(extrasMap)
@@ -114,6 +116,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
       .publicKey(obj.getString(PUBLIC_KEY))
       .clientName(obj.getString(CLIENT_NAME))
       .products(productsArray)
+      .logLevel(logLevel)
 
     if (obj.has(ACCOUNT_SUBTYPES)) {
       extrasMap[ACCOUNT_SUBTYPES] = obj.getJSONObject(ACCOUNT_SUBTYPES).toString()

--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -81,17 +81,18 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
 
     // If we're initializing with a Link token, we will not use or
     // accept many of the client-side configs.
-    var isUsingLinkToken = false;
-    maybeGetStringField(obj, TOKEN)?.let {
+    val token = maybeGetStringField(obj, TOKEN)
+    token?.let {
       if (it.startsWith(LINK_TOKEN_PREFIX)) {
-        isUsingLinkToken = true;
-      }
-    }
+        val builder = LinkTokenConfiguration.Builder()
+          .token(obj.getString(TOKEN))
 
-    if (isUsingLinkToken) {
-      val builder = LinkTokenConfiguration.Builder()
-        .token(obj.getString(TOKEN))
-      return builder.build().toLinkConfiguration()
+        if (extrasMap.isNotEmpty()) {
+          builder.extraParams(extrasMap)
+        }
+
+        return builder.build().toLinkConfiguration()
+      }
     }
 
     val productsArray = ArrayList<PlaidProduct>()

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -125,6 +125,12 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
 
     if (isUsingLinkToken) {
       linkConfiguration = [[PLKConfiguration alloc] initWithLinkToken:linkTokenInput];
+      if ([oauthRedirectUri length] > 0) {
+          linkConfiguration.oauthRedirectUri = [NSURL URLWithString:oauthRedirectUri];
+      }
+      if ([oauthNonce length] > 0) {
+          linkConfiguration.oauthNonce = oauthNonce;
+      }
     } else {
       linkConfiguration = [[PLKConfiguration alloc] initWithKey:key
                                                             env:environment
@@ -207,10 +213,11 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
     if ([linkTokenInput length] > 0) {
         if (isUsingLinkToken) {
             self.linkViewController = [[PLKPlaidLinkViewController alloc] initWithLinkToken:linkTokenInput
+                                                                               oauthStateId:oauthStateId
                                                                               configuration:linkConfiguration
                                                                                    delegate:self.linkViewDelegate];
         }
-        if ([linkTokenInput hasPrefix:kRNLinkKitItemAddTokenPrefix]) {
+        else if ([linkTokenInput hasPrefix:kRNLinkKitItemAddTokenPrefix]) {
             self.linkViewController = [[PLKPlaidLinkViewController alloc] initWithItemAddToken:linkTokenInput
                                                                                  configuration:linkConfiguration
                                                                                       delegate:self.linkViewDelegate];

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -226,7 +226,6 @@ RCT_EXPORT_METHOD(dismiss) {
 }
 
 - (PLKConfiguration*)getLegacyLinkConfiguration:(NSDictionary*)configuration {
-  // Configuration
   NSString *key = [RCTConvert NSString:configuration[kRNLinkKitConfigPublicKeyKey]];
   NSString *env = [RCTConvert NSString:configuration[kRNLinkKitConfigEnvKey]];
   NSArray<NSString*> *products = [RCTConvert NSStringArray:configuration[kRNLinkKitConfigProductsKey]];


### PR DESCRIPTION
- Makes required configs optional (because of server-side configs). I was unable to make the props optional with xor behavior because this repo does not yet use typescript.

- If a link token is used, construct the proper configs for both Android and iOS.

TODO:
- [x] Update the iOS / Android SDK versions after they are released
- [x] Test that Android Works (after new Android release is made)
- [x] Test that iOS Works (after new iOS release is made)
