### PR TITLE
Fix institution in Android openLink

### DIFF
--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -56,6 +56,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     private const val WEBHOOK = "webhook"
     private const val DATA = "data"
     private const val RESULT_CODE = "resultCode"
+    private const val INSTITUTION = "institution"
   }
 
   override fun getName(): String {
@@ -159,6 +160,10 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
 
       maybeGetStringField(obj, WEBHOOK)?.let {
         builder.webhook(it)
+      }
+
+      maybeGetStringField(obj, INSTITUTION)?.let {
+        extrasMap[INSTITUTION] = it
       }
 
       if (extrasMap.isNotEmpty()) {


### PR DESCRIPTION
It's handled in iOS [here](https://github.com/plaid/react-native-plaid-link-sdk/blob/8a68a13a143495955bc430ea80ead69c4ca4aeb1/ios/RNLinksdk.m#L109) but it isn't handled in Android.

This PR fixes that and makes the experience more consitent