### PR TITLE
Don't crash when no error handler

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -7,8 +7,16 @@ export const openLink = async ({ onExit, onSuccess, ...serializable }) => {
     const constants = NativeModules.PlaidAndroid.getConstants();
     NativeModules.PlaidAndroid.startLinkActivityForResult(
       JSON.stringify(serializable),
-      result => { onSuccess(result.data); },
-      result => { onExit(result.data); }
+      result => {
+        if (onSuccess != null) {
+          onSuccess(result.data);
+        }
+      },
+      result => {
+        if (onExit != null) {
+          onExit(result.data);
+        }
+      }
     );
   } else {
     NativeModules.RNLinksdk.create(serializable);


### PR DESCRIPTION
Rationale: iOS had a check to see if the error handler was null before returning a result, whereas Android didn't. Adding this makes both platforms behave similarly.

Fixes issue #151  