### PR TITLE
Upgrade to iOS LinkKit v2.0.0

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
-import React, {useEffect, useRef, useState} from 'react';
-import { Linking, NativeEventEmitter, NativeModules, Platform, TouchableOpacity } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Linking,
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+  TouchableOpacity,
+} from 'react-native';
 
 /**
  * A hook that registers a listener on the plaid emitter for the 'onEvent' type.
@@ -8,7 +14,7 @@ import { Linking, NativeEventEmitter, NativeModules, Platform, TouchableOpacity 
  *
  * @param onEventListener the listener to call
  */
-export const usePlaidEmitter = onEventListener => {
+export const usePlaidEmitter = (onEventListener) => {
   useEffect(() => {
     const emitter = new NativeEventEmitter(
       Platform.OS === 'ios'
@@ -27,12 +33,12 @@ export const openLink = async ({ onExit, onSuccess, ...serializable }) => {
   if (Platform.OS === 'android') {
     NativeModules.PlaidAndroid.startLinkActivityForResult(
       JSON.stringify(serializable),
-      result => {
+      (result) => {
         if (onSuccess != null) {
           onSuccess(result.data);
         }
       },
-      result => {
+      (result) => {
         if (onExit != null) {
           onExit(result.data);
         }
@@ -78,20 +84,20 @@ const handlePress = (linkProps, componentProps) => {
   }
 };
 
-const useMount = func => useEffect(() => func(), []);
+const useMount = (func) => useEffect(() => func(), []);
 
 export const useDeepLinkRedirector = () => {
   const _handleListenerChange = (event) => {
-    if (event.url !== null) {
-    NativeModules.RNLinksdk.continueFromRedirectUriString(event.url);
+    if (event.url !== null && Platform.OS === 'ios') {
+      NativeModules.RNLinksdk.continueFromRedirectUriString(event.url);
     }
   };
 
-    useEffect(() => {
-      Linking.addEventListener("url", _handleListenerChange);
+  useEffect(() => {
+    Linking.addEventListener('url', _handleListenerChange);
 
     return function cleanup() {
-      Linking.removeEventListener("url", _handleListenerChange);
+      Linking.removeEventListener('url', _handleListenerChange);
     };
   }, []);
 };
@@ -128,7 +134,7 @@ PlaidLink.propTypes = {
   //
   // [DEPRECATED] - instead, pass a Link token into the token field.
   // Create a Link token with the /link/token/create endpoint.
-  publicKey: props => {
+  publicKey: (props) => {
     if (!props.publicKey && !props.token) {
       return new Error(`One of props 'publicKey' or 'token' is required`);
     }
@@ -211,7 +217,7 @@ PlaidLink.propTypes = {
   // An oauthRedirectUri is required to support OAuth authentication flows when
   // launching or re-launching Link within a WebView and using one or more
   // European country codes.
-  oauthRedirectUri: function(props, propName) {
+  oauthRedirectUri: function (props, propName) {
     let value = props[propName];
     if (value === undefined || value === null) {
       return;

--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {useEffect} from 'react';
-import { NativeEventEmitter, NativeModules, Platform, TouchableOpacity } from 'react-native';
+import React, {useEffect, useRef, useState} from 'react';
+import { AppState, Linking, NativeEventEmitter, NativeModules, Platform, TouchableOpacity } from 'react-native';
 
 /**
  * A hook that registers a listener on the plaid emitter for the 'onEvent' type.
@@ -78,6 +78,24 @@ const handlePress = (linkProps, componentProps) => {
   if (componentProps && componentProps.onPress) {
     componentProps.onPress();
   }
+};
+
+const useMount = func => useEffect(() => func(), []);
+
+export const useDeepLinkRedirector = () => {
+  const _handleListenerChange = (event) => {
+    if (event.url !== null) {
+    NativeModules.RNLinksdk.continueFromRedirectUriString(event.url);
+    }
+  };
+
+    useEffect(() => {
+      Linking.addEventListener("url", _handleListenerChange);
+
+    return function cleanup() {
+      Linking.removeEventListener("url", _handleListenerChange);
+    };
+  }, []);
 };
 
 export const PlaidLink = ({

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -120,11 +120,11 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
         [weakSelf dismissLinkViewController];
 
         if (strongSelf.completionCallback) {
+            NSDictionary *exitMetadata = [RNLinksdk dictionaryFromExitMetadata:exit.metadata];
             if (exit.error) {
-                NSDictionary *exitMetadata = [RNLinksdk dictionaryFromExitMetadata:exit.metadata];
                 strongSelf.completionCallback(@[RCTMakeError(exit.error.localizedDescription, nil, nil), exitMetadata]);
             } else {
-                strongSelf.completionCallback(@[[NSNull null], exit.metadata]);
+                strongSelf.completionCallback(@[[NSNull null], exitMetadata]);
             }
             strongSelf.completionCallback = nil;
         }
@@ -494,7 +494,7 @@ RCT_EXPORT_METHOD(dismiss) {
     return @{
         @"link_session_id": metadata.linkSessionID,
         @"institution": [self dictionaryFromInstitution:metadata.insitution],
-        @"accounts": metadata.accounts,
+        @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts],
         @"metadata_json": metadata.metadataJSON ?: @"<null>",
     };
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -12,7 +12,6 @@ static NSString* const kRNLinkKitConfigClientNameKey = @"clientName";
 static NSString* const kRNLinkKitConfigWebhookKey = @"webhook";
 static NSString* const kRNLinkKitConfigLinkCustomizationName = @"linkCustomizationName";
 static NSString* const kRNLinkKitConfigLinkTokenKey = @"token";
-static NSString* const kRNLinkKitConfigPaymentTokenKey = @"paymentToken";
 static NSString* const kRNLinkKitConfigSelectAccountKey = @"selectAccount";
 static NSString* const kRNLinkKitConfigUserLegalNameKey = @"userLegalName";
 static NSString* const kRNLinkKitConfigUserEmailAddressKey = @"userEmailAddress";
@@ -36,6 +35,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 
 NSString* const kRNLinkKitLinkTokenPrefix = @"link-";
 NSString* const kRNLinkKitItemAddTokenPrefix = @"item-add-";
+NSString* const kRNLinkKitPaymentTokenPrefix = @"payment";
 
 @interface RNLinksdk ()
 @property (nonatomic, strong) id<PLKHandler> linkHandler;
@@ -192,7 +192,7 @@ RCT_EXPORT_METHOD(dismiss) {
 - (PLKLinkPublicKeyConfiguration *)getLegacyLinkConfiguration:(NSDictionary *)configuration
                                              onSuccessHandler:(void(^)(PLKLinkSuccess *))onSuccessHandler  {
   NSString *key = [RCTConvert NSString:configuration[kRNLinkKitConfigPublicKeyKey]];
-  NSString *paymentTokenInput = [RCTConvert NSString:configuration[kRNLinkKitConfigPaymentTokenKey]];
+  NSString *tokenInput = [RCTConvert NSString:configuration[kRNLinkKitConfigLinkTokenKey]];
   NSString *env = [RCTConvert NSString:configuration[kRNLinkKitConfigEnvKey]];
   NSArray<NSString*> *productsInput = [RCTConvert NSStringArray:configuration[kRNLinkKitConfigProductsKey]];
   NSString *clientName = [RCTConvert NSString:configuration[kRNLinkKitConfigClientNameKey]];
@@ -208,8 +208,9 @@ RCT_EXPORT_METHOD(dismiss) {
   NSString *language = [RCTConvert NSString:configuration[kRNLinkKitConfigLanguageKey]];
     
     PLKLinkPublicKeyConfigurationToken *token;
-    if ([paymentTokenInput length] > 0) {
-        token = [PLKLinkPublicKeyConfigurationToken createWithPaymentToken:paymentTokenInput publicKey:key];
+    BOOL isPaymentToken = [tokenInput hasPrefix:kRNLinkKitPaymentTokenPrefix];
+    if (isPaymentToken) {
+        token = [PLKLinkPublicKeyConfigurationToken createWithPaymentToken:tokenInput publicKey:key];
     } else {
         token = [PLKLinkPublicKeyConfigurationToken createWithPublicKey:key];
     }
@@ -223,7 +224,7 @@ RCT_EXPORT_METHOD(dismiss) {
                                                                                                            token:token
                                                                                                     countryCodes:countryCodes
                                                                                                        onSuccess:onSuccessHandler];
-  if([linkCustomizationName length] > 0) {
+  if ([linkCustomizationName length] > 0) {
       linkConfiguration.linkCustomizationName = linkCustomizationName;
   }
   if ([webhook length] > 0) {

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -73,8 +73,7 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
     return @{
-        // TODO: Actual version numbers again
-        kRNLinkKitVersionConstant: [NSString stringWithFormat:@"%s+%.0f", "LinkKitVersionString", 1],
+        kRNLinkKitVersionConstant: [NSString stringWithFormat:@"%s+%.0f", LinkKitVersionString, LinkKitVersionNumber],
     };
 }
 
@@ -591,24 +590,30 @@ RCT_EXPORT_METHOD(dismiss) {
     };
 }
 
-+ (NSString *)stringForExitStatus:(PLKExitStatus)exitStatus {
-    switch (exitStatus) {
-        case PLKExitStatusNone:
++ (NSString *)stringForExitStatus:(PLKExitStatus *)exitStatus {
+    if (!exitStatus) {
+        return @"<null>";
+    }
+
+    if (exitStatus.unknownStringValue) {
+        return exitStatus.unknownStringValue;
+    }
+
+    switch (exitStatus.value) {
+        case PLKExitStatusValueNone:
             return @"<null>";
-        case PLKExitStatusRequiresQuestions:
+        case PLKExitStatusValueRequiresQuestions:
             return @"requires_questions";
-        case PLKExitStatusRequiresSelections:
+        case PLKExitStatusValueRequiresSelections:
             return @"requires_selections";
-        case PLKExitStatusRequiresCode:
+        case PLKExitStatusValueRequiresCode:
             return @"requires_code";
-        case PLKExitStatusChooseDevice:
+        case PLKExitStatusValueChooseDevice:
             return @"choose_device";
-        case PLKExitStatusRequiresCredentials:
+        case PLKExitStatusValueRequiresCredentials:
             return @"requires_credentials";
-        case PLKExitStatusInstitutionNotFound:
+        case PLKExitStatusValueInstitutionNotFound:
             return @"institution_not_found";
-        case PLKExitStatusUnknown:
-            return @"unknown";
     }
     return @"unknown";
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -155,9 +155,9 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
         self.linkHandler = [PLKPlaid createWithLinkPublicKeyConfiguration:config
                                                                     error:NULL];
     }
+
     if ([institution length] > 0) {
         self.institutionID = institution;
-
     }
 }
 
@@ -165,7 +165,8 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)callback) {
     if (self.linkHandler) {
         self.completionCallback = callback;
         self.presentingViewController = RCTPresentedViewController();
-        [self.linkHandler openWithContextViewController:self.presentingViewController];
+        NSDictionary *options = self.institutionID.length > 0 ? @{@"institution_id": self.institutionID} : @{};
+        [self.linkHandler openWithContextViewController:self.presentingViewController options:options];
     } else {
         callback(@[RCTMakeError(@"create was not called", nil, nil)]);
     }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -89,7 +89,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(continueFromRedirectUriString:(NSString *)redirectUriString) {
     NSURL *receivedRedirectUri = (id)redirectUriString == [NSNull null] ? nil : [NSURL URLWithString:redirectUriString];
-    
+
     if (receivedRedirectUri && self.linkHandler) {
        [self.linkHandler continueFromRedirectUri:receivedRedirectUri];
     }
@@ -304,7 +304,7 @@ RCT_EXPORT_METHOD(dismiss) {
     
     for (NSString *type in accountSubtypesDictionary.allKeys) {
         NSArray<NSString *> *subtypes = accountSubtypesDictionary[type] ?: @[];
-        
+
         for (NSString *subtype in subtypes) {
             id<PLKAccountSubtype> accountSubtype = [self accountSubtypeFromTypeString:type subtypeString:subtype];
             if (accountSubtype) {
@@ -492,9 +492,9 @@ RCT_EXPORT_METHOD(dismiss) {
 
 + (NSDictionary *)dictionaryFromSuccessMetadata:(PLKSuccessMetadata *)metadata {
     return @{
-        @"link_session_id": metadata.linkSessionID,
-        @"institution": [self dictionaryFromInstitution:metadata.insitution],
-        @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts],
+        @"link_session_id": metadata.linkSessionID ?: @"<null>",
+        @"institution": [self dictionaryFromInstitution:metadata.insitution] ?: @"<null>",
+        @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts] ?: @"<null>",
         @"metadata_json": metadata.metadataJSON ?: @"<null>",
     };
 }
@@ -511,12 +511,12 @@ RCT_EXPORT_METHOD(dismiss) {
 
 + (NSDictionary *)dictionaryFromAccount:(PLKAccount *)account {
     return @{
-        @"id": account.ID,
-        @"name": account.name,
+        @"id": account.ID ?: @"<null>",
+        @"name": account.name ?: @"<null>",
         @"mask": account.mask ?: @"<null>",
-        @"subtype": [self subtypeNameForAccountSubtype:account.subtype],
-        @"type": [self typeNameForAccountSubtype:account.subtype],
-        @"verification_status": [self stringForVerificationStatus:account.verificationStatus],
+        @"subtype": [self subtypeNameForAccountSubtype:account.subtype] ?: @"<null>",
+        @"type": [self typeNameForAccountSubtype:account.subtype] ?: @"<null>",
+        @"verification_status": [self stringForVerificationStatus:account.verificationStatus] ?: @"<null>",
     };
 }
 
@@ -524,11 +524,11 @@ RCT_EXPORT_METHOD(dismiss) {
     if (!verificationStatus) {
         return @"<null>";
     }
-    
+
     if (verificationStatus.unknownStringValue) {
         return verificationStatus.unknownStringValue;
     }
-    
+
     switch (verificationStatus.value) {
         case PLKVerificationStatusValueNone:
             return @"<null>";
@@ -539,7 +539,7 @@ RCT_EXPORT_METHOD(dismiss) {
         case PLKVerificationStatusValueManuallyVerified:
             return @"manually_verified";
     }
-    
+
     return @"unknown";
 }
 
@@ -569,23 +569,23 @@ RCT_EXPORT_METHOD(dismiss) {
 
 + (NSDictionary *)dictionaryFromInstitution:(PLKInstitution *)institution {
     return @{
-        @"name": institution.name,
-        @"id": institution.ID,
+        @"name": institution.name ?: @"<null>",
+        @"id": institution.ID ?: @"<null>",
     };
 }
 
 + (NSDictionary *)dictionaryFromEventMetadata:(PLKEventMetadata *)metadata {
     return @{
         @"error": metadata.error ?: @"<null>",
-        @"exit_status": [self stringForExitStatus:metadata.exitStatus],
-        @"institution_id": metadata.institutionID ?: @"",
-        @"institution_name": metadata.institutionName ?: @"",
-        @"instituion_search_query": metadata.institutionSearchQuery ?: @"",
-        @"link_session_id": metadata.linkSessionID,
-        @"mfa_type": [self stringForMfaType:metadata.mfaType],
+        @"exit_status": [self stringForExitStatus:metadata.exitStatus] ?: @"<null>",
+        @"institution_id": metadata.institutionID ?: @"<null>",
+        @"institution_name": metadata.institutionName ?: @"<null>",
+        @"instituion_search_query": metadata.institutionSearchQuery ?: @"<null>",
+        @"link_session_id": metadata.linkSessionID ?: @"<null>",
+        @"mfa_type": [self stringForMfaType:metadata.mfaType] ?: @"<null>",
         @"request_id": metadata.requestID ?: @"<null>",
-        @"timestamp": metadata.timestamp,
-        @"view_name": [self stringForViewName:metadata.viewName],
+        @"timestamp": metadata.timestamp ?: @"<null>",
+        @"view_name": [self stringForViewName:metadata.viewName] ?: @"<null>",
         @"metadata_json": metadata.metadataJSON ?: @"<null>",
     };
 }
@@ -631,7 +631,7 @@ RCT_EXPORT_METHOD(dismiss) {
         case PLKMFATypeSelections:
             return @"selections";
     }
-    
+
     return @"unknown";
 }
 
@@ -639,11 +639,11 @@ RCT_EXPORT_METHOD(dismiss) {
     if (!viewName) {
         return @"<null>";
     }
-    
+
     if (viewName.unknownStringValue) {
         return viewName.unknownStringValue;
     }
-    
+
     switch (viewName.value) {
         case PLKViewNameValueNone:
             return @"<null>";
@@ -670,17 +670,17 @@ RCT_EXPORT_METHOD(dismiss) {
         case PLKViewNameValueSelectInstitution:
             return @"SELECT_INSTITUTION";
     }
-    
+
     return @"unknown";
 }
 
 + (NSDictionary *)dictionaryFromExitMetadata:(PLKExitMetadata *)metadata {
     return @{
-        @"status": [self stringForExitStatus:metadata.status],
+        @"status": [self stringForExitStatus:metadata.status] ?: @"<null>",
         @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"<null>",
-        @"request_id": metadata.requestID,
-        @"link_session_id": metadata.linkSessionID,
-        @"metadata_json": metadata.metadataJSON,
+        @"request_id": metadata.requestID ?: @"<null>",
+        @"link_session_id": metadata.linkSessionID ?: @"<null>",
+        @"metadata_json": metadata.metadataJSON ?: @"<null>",
     };
 }
 

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -316,161 +316,169 @@ RCT_EXPORT_METHOD(dismiss) {
 
 + (id<PLKAccountSubtype> __nullable)accountSubtypeFromTypeString:(NSString *)typeString
                                                    subtypeString:(NSString *)subtypeString {
-    if ([typeString.lowercaseString isEqualToString:@"other"]) {
-        
-    } else if ([typeString.lowercaseString isEqualToString:@"credit"]) {
-        if ([subtypeString.lowercaseString isEqualToString:@"all"]) {
+    NSString *normalizedTypeString = typeString.lowercaseString;
+    NSString *normalizedSubtypeString = subtypeString.lowercaseString;
+    if ([normalizedTypeString isEqualToString:@"other"]) {
+        if ([normalizedSubtypeString isEqualToString:@"all"]) {
+            return [PLKAccountSubtypeOther createWithValue:PLKAccountSubtypeValueOtherAll];
+        } else if ([normalizedSubtypeString isEqualToString:@"other"]) {
+            return [PLKAccountSubtypeOther createWithValue:PLKAccountSubtypeValueOtherOther];
+        } else {
+            return [PLKAccountSubtypeOther createWithRawStringValue:normalizedSubtypeString];
+        }
+    } else if ([normalizedTypeString isEqualToString:@"credit"]) {
+        if ([normalizedSubtypeString isEqualToString:@"all"]) {
             return [PLKAccountSubtypeCredit createWithValue:PLKAccountSubtypeValueCreditAll];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"credit card"]) {
-            return [PLKAccountSubtypeCredit createWithValue:PLKAccountSubtypeValueCreditAll];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"paypal"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"credit card"]) {
+            return [PLKAccountSubtypeCredit createWithValue:PLKAccountSubtypeValueCreditCreditCard];
+        } else if ([normalizedSubtypeString isEqualToString:@"paypal"]) {
             return [PLKAccountSubtypeCredit createWithValue:PLKAccountSubtypeValueCreditPaypal];
         } else {
             return [PLKAccountSubtypeCredit createWithUnknownValue:subtypeString];
         }
-    } else if ([typeString.lowercaseString isEqualToString:@"loan"]) {
-        if ([subtypeString.lowercaseString isEqualToString:@"all"]) {
+    } else if ([normalizedTypeString isEqualToString:@"loan"]) {
+        if ([normalizedSubtypeString isEqualToString:@"all"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanAll];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"auto"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"auto"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanAuto];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"business"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"business"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanBusiness];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"commercial"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"commercial"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanCommercial];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"construction"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"construction"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanConstruction];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"consumer"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"consumer"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanConsumer];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"home equity"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"home equity"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanHomeEquity];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"line of credit"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"line of credit"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanLineOfCredit];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"loan"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"loan"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanLoan];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"mortgage"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"mortgage"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanMortgage];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"overdraft"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"overdraft"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanOverdraft];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"student"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"student"]) {
             return [PLKAccountSubtypeLoan createWithValue:PLKAccountSubtypeValueLoanStudent];
         } else {
             return [PLKAccountSubtypeLoan createWithUnknownValue:subtypeString];
         }
-    } else if ([typeString.lowercaseString isEqualToString:@"depository"]) {
-        if ([subtypeString.lowercaseString isEqualToString:@"all"]) {
+    } else if ([normalizedTypeString isEqualToString:@"depository"]) {
+        if ([normalizedSubtypeString isEqualToString:@"all"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryAll];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"cash management"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"cash management"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryCashManagement];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"cd"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"cd"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryCd];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"checking"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"checking"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryChecking];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"ebt"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"ebt"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryEbt];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"hsa"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"hsa"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryHsa];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"money market"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"money market"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryMoneyMarket];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"paypal"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"paypal"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryPaypal];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"prepaid"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"prepaid"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositoryPrepaid];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"savings"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"savings"]) {
             return [PLKAccountSubtypeDepository createWithValue:PLKAccountSubtypeValueDepositorySavings];
         } else {
             return [PLKAccountSubtypeDepository createWithUnknownValue:subtypeString];
         }
 
-    } else if ([typeString.lowercaseString isEqualToString:@"investment"]) {
-        if ([subtypeString.lowercaseString isEqualToString:@"all"]) {
+    } else if ([normalizedTypeString isEqualToString:@"investment"]) {
+        if ([normalizedSubtypeString isEqualToString:@"all"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentAll];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"401a"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"401a"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestment401a];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"401k"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"401k"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestment401k];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"403B"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"403B"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestment403B];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"457b"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"457b"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestment457b];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"529"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"529"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestment529];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"brokerage"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"brokerage"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentBrokerage];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"cash isa"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"cash isa"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentCashIsa];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"education savings account"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"education savings account"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentEducationSavingsAccount];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"fixed annuity"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"fixed annuity"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentFixedAnnuity];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"gic"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"gic"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentGic];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"health reimbursement arrangement"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"health reimbursement arrangement"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentHealthReimbursementArrangement];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"hsa"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"hsa"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentHsa];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"ira"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"ira"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentIra];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"isa"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"isa"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentIsa];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"keogh"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"keogh"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentKeogh];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"lif"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"lif"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentLif];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"lira"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"lira"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentLira];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"lrif"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"lrif"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentLrif];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"lrsp"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"lrsp"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentLrsp];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"mutual fund"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"mutual fund"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentMutualFund];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"non-taxable brokerage account"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"non-taxable brokerage account"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentNonTaxableBrokerageAccount];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"pension"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"pension"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentPension];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"plan"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"plan"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentPlan];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"prif"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"prif"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentPrif];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"profit sharing plan"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"profit sharing plan"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentProfitSharingPlan];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"rdsp"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"rdsp"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRdsp];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"resp"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"resp"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentResp];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"retirement"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"retirement"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRetirement];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"rlif"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"rlif"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRlif];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"roth 401k"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"roth 401k"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRoth401k];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"roth"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"roth"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRoth];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"rrif"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"rrif"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRrif];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"rrsp"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"rrsp"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentRrsp];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"sarsep"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"sarsep"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentSarsep];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"sep ira"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"sep ira"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentSepIra];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"simple ira"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"simple ira"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentSimpleIra];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"sipp"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"sipp"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentSipp];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"stock plan"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"stock plan"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentStockPlan];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"tfsa"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"tfsa"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentTfsa];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"thrift savings plan"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"thrift savings plan"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentThriftSavingsPlan];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"trust"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"trust"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentTrust];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"ugma"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"ugma"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentUgma];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"utma"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"utma"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentUtma];
-        } else if ([subtypeString.lowercaseString isEqualToString:@"variable annuity"]) {
+        } else if ([normalizedSubtypeString isEqualToString:@"variable annuity"]) {
           return [PLKAccountSubtypeInvestment createWithValue:PLKAccountSubtypeValueInvestmentVariableAnnuity];
         } else {
           return [PLKAccountSubtypeInvestment createWithUnknownValue:subtypeString];
@@ -482,7 +490,7 @@ RCT_EXPORT_METHOD(dismiss) {
 
 + (NSDictionary *)dictionaryFromSuccessMetadata:(PLKSuccessMetadata *)metadata {
     return @{
-        @"linkSessionID": metadata.linkSessionID,
+        @"link_session_id": metadata.linkSessionID,
         @"institution": [self dictionaryFromInstitution:metadata.insitution],
         @"accounts": metadata.accounts,
         @"metadata_json": metadata.metadataJSON ?: @"<null>",

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -209,8 +209,11 @@ RCT_EXPORT_METHOD(dismiss) {
     
     PLKLinkPublicKeyConfigurationToken *token;
     BOOL isPaymentToken = [tokenInput hasPrefix:kRNLinkKitPaymentTokenPrefix];
+    BOOL isItemAddToken = [tokenInput hasPrefix:kRNLinkKitItemAddTokenPrefix];
     if (isPaymentToken) {
         token = [PLKLinkPublicKeyConfigurationToken createWithPaymentToken:tokenInput publicKey:key];
+    } else if (isItemAddToken) {
+        token = [PLKLinkPublicKeyConfigurationToken createWithPublicToken:tokenInput publicKey:key];
     } else {
         token = [PLKLinkPublicKeyConfigurationToken createWithPublicKey:key];
     }


### PR DESCRIPTION
Hi,

This is a draft PR to upgrade the RN SDK to rely on iOS v2. I'm putting it up as a draft to start discussion around how we want to surface the new continueFromRedirectUri API in LinkKit v2 through RN.

I see a few potential options:

1. A native method for continuingFromRedirectUri and guidance for integrators to call that method from their AppDelegate
2. A method bridged to JS (as in this PR), and expose that method through PlaidLink.js – I'm not sure if the Javascript layer of our integrators' apps already has the requisite redirect URI in scope.
3. An additional prop (e.g., `recievedRedirectUri`) that results in RNLinksdk calling continue in its internal create method.

--
The TODOs will be addressed in a commit, I wanted to get this PR out in Draft mode ASAP to facilitate discussion.