### PR TITLE
Use useDeepLinkRedirector hook inside PlaidLink component to ensure i…

### DIFF
--- a/PlaidLink.js
+++ b/PlaidLink.js
@@ -111,6 +111,9 @@ export const PlaidLink = ({
   ...linkProps
 }) => {
   const Component = component;
+
+  useDeepLinkRedirector();
+
   return (
     <Component
       {...componentProps}


### PR DESCRIPTION
…OS OAuth can redirect from app-to-app

By embedding the hook inside PlaidLink, we don't require clients to do anything special in the RN layer for deep link handling