### PR TITLE
Choose what config to pass into link

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -109,6 +109,6 @@ export const useDeepLinkRedirector = () => {
 
 export const PlaidLink = (props: PlaidLinkProps) => {
   useDeepLinkRedirector();
-
-  return <Pressable onPress={() => openLink(props.config, props.onSuccess, props.onExit)}>{props.children}</Pressable>;
+  let config = props.tokenConfig ? props.tokenConfig : props.publicKeyConfig!;
+  return <Pressable onPress={() => openLink(config, props.onSuccess, props.onExit)}>{props.children}</Pressable>;
 };


### PR DESCRIPTION
Quick patch on top of https://github.com/plaid/react-native-plaid-link-sdk/pull/255 where we missed to unpack the properties and only provide a single configuration into Link.