### PR TITLE
Define build types explicitly to satisfy our internal CI

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,15 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    buildTypes {
+        release {
+            debuggable = false
+        }
+        debug {
+            debuggable = true
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
Port of build type changes in https://github.com/plaid/react-native-plaid-link-sdk/pull/259 to be able to test the fix without dependency on an unreleased SDK version.