### PR TITLE
Update example bindings

### DIFF
--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -10,8 +10,8 @@ import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.plaid.gson.PlaidJsonConverter
 import com.plaid.link.Plaid
 import com.plaid.link.configuration.LinkLogLevel
 import com.plaid.link.configuration.LinkPublicKeyConfiguration
@@ -19,20 +19,8 @@ import com.plaid.link.configuration.LinkTokenConfiguration
 import com.plaid.link.configuration.PlaidEnvironment
 import com.plaid.link.configuration.PlaidProduct
 import com.plaid.link.event.LinkEvent
-import com.plaid.link.event.LinkEventName
-import com.plaid.link.event.LinkEventViewName
-import com.plaid.link.result.LinkAccount
-import com.plaid.link.result.LinkAccountSubtype
-import com.plaid.link.result.LinkAccountType
-import com.plaid.link.result.LinkAccountVerificationStatus
-import com.plaid.link.result.LinkErrorCode
-import com.plaid.link.result.LinkErrorType
-import com.plaid.link.result.LinkExit
-import com.plaid.link.result.LinkSuccess
-import com.plaid.link.result.LinkExitMetadataStatus
 import com.plaid.link.exception.LinkException
 import com.plaid.link.result.LinkResultHandler
-import com.plaid.gson.PlaidJsonConverter
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.ArrayList
@@ -60,8 +48,6 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     private const val USER_PHONE = "userPhoneNumber"
     private const val WEBHOOK = "webhook"
     private const val EXTRAS = "extras"
-    private const val DATA = "data"
-    private const val RESULT_CODE = "resultCode"
     private const val LINK_TOKEN_PREFIX = "link"
   }
 
@@ -278,16 +264,14 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     resultCode: Int,
     data: Intent?
   ) {
-    val result = WritableNativeMap()
-
     val linkHandler = LinkResultHandler(
       onSuccess = { success ->
-        result.putMap(DATA, convertJsonToMap(JSONObject(jsonConverter.convert(success))))
+        val result = convertJsonToMap(JSONObject(jsonConverter.convert(success)))
         print(result)
         this.onSuccessCallback?.invoke(result)
       },
       onExit = { exit ->
-        result.putMap(DATA, convertJsonToMap(JSONObject(jsonConverter.convert(exit))))
+        val result = convertJsonToMap(JSONObject(jsonConverter.convert(exit)))
         print(result)
         this.onExitCallback?.invoke(result)
       }

--- a/android/src/main/java/com/plaid/gson/PlaidJsonConverter.kt
+++ b/android/src/main/java/com/plaid/gson/PlaidJsonConverter.kt
@@ -3,15 +3,16 @@
  */
 package com.plaid.gson
 
-import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.plaid.gson.RNAccountAdapter
-import com.plaid.link.configuration.LinkLogLevel
-import com.plaid.link.configuration.LinkPublicKeyConfiguration
-import com.plaid.link.configuration.LinkTokenConfiguration
-import com.plaid.link.configuration.PlaidEnvironment
-import com.plaid.link.configuration.PlaidProduct
+import com.plaid.internal.networking.adapter.AccountSubtypeAdapter
+import com.plaid.internal.networking.adapter.AccountTypeAdapter
+import com.plaid.internal.networking.adapter.LinkAccountVerificationStatusAdapter
+import com.plaid.internal.networking.adapter.LinkEventNameAdapter
+import com.plaid.internal.networking.adapter.LinkEventViewNameAdapter
+import com.plaid.internal.networking.adapter.LinkExitMetadataStatusAdapter
+import com.plaid.internal.networking.adapter.PlaidErrorCodeAdapter
+import com.plaid.internal.networking.adapter.PlaidErrorTypeAdapter
 import com.plaid.link.event.LinkEvent
 import com.plaid.link.event.LinkEventName
 import com.plaid.link.event.LinkEventViewName
@@ -21,23 +22,14 @@ import com.plaid.link.result.LinkAccountType
 import com.plaid.link.result.LinkAccountVerificationStatus
 import com.plaid.link.result.LinkErrorCode
 import com.plaid.link.result.LinkErrorType
-import com.plaid.link.result.LinkExitMetadataStatus
 import com.plaid.link.result.LinkExit
+import com.plaid.link.result.LinkExitMetadataStatus
 import com.plaid.link.result.LinkSuccess
-import com.plaid.internal.networking.adapter.AccountSubtypeAdapter
-import com.plaid.internal.networking.adapter.AccountTypeAdapter
-import com.plaid.internal.networking.adapter.LinkAccountVerificationStatusAdapter
-import com.plaid.internal.networking.adapter.LinkEventNameAdapter
-import com.plaid.internal.networking.adapter.LinkEventViewNameAdapter
-import com.plaid.internal.networking.adapter.LinkExitMetadataStatusAdapter
-import com.plaid.internal.networking.adapter.PlaidErrorCodeAdapter
-import com.plaid.internal.networking.adapter.PlaidErrorTypeAdapter
 
 class PlaidJsonConverter {
 
- private val snakeCaseGson: Gson by lazy {
+  private val gson: Gson by lazy {
     GsonBuilder().apply {
-      setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       this.registerTypeAdapter(
         LinkAccount::class.java,
         RNAccountAdapter()
@@ -77,17 +69,16 @@ class PlaidJsonConverter {
     }.create()
   }
 
-  fun convert(linkSuccess: LinkSuccess) : String {
-    return snakeCaseGson.toJson(linkSuccess)
+  fun convert(linkSuccess: LinkSuccess): String {
+    return gson.toJson(linkSuccess)
+  }
+
+  fun convert(linkExit: LinkExit): String {
+    return gson.toJson(linkExit)
 
   }
 
-  fun convert(linkExit: LinkExit) : String {
-    return snakeCaseGson.toJson(linkExit)
-
-  }
-
-  fun convert(linkEvent: LinkEvent) : String {
-    return snakeCaseGson.toJson(linkEvent).replace("event_name", "event")
+  fun convert(linkEvent: LinkEvent): String {
+    return gson.toJson(linkEvent).replace("event_name", "event")
   }
 }

--- a/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
+++ b/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
@@ -34,8 +34,8 @@ class RNAccountAdapter : JsonSerializer<LinkAccount> {
       // Special handling around account subtype
       val subtype = context?.serialize(src.subtype)?.asJsonObject
       subtype?.let {
-        addProperty("type", it.get("account_type").asString)
-        addProperty("subtype", it.get("json").asString)
+        addProperty("type", it.get("account_type")?.asString)
+        addProperty("subtype", it.get("json")?.asString)
       }
     }
     return obj

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -5,7 +5,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { HeaderBackButton } from '@react-navigation/stack';
 import { StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import ErrorScreen from './components/ErrorScreen';
+import ExitScreen from './components/ExitScreen';
 import SuccessScreen from './components/SuccessScreen';
 import HomeScreen from './components/HomeScreen';
 import { PlaidTheme } from './components/style';
@@ -42,8 +42,8 @@ const App = (): React.ReactElement => {
             }}
           />
           <Stack.Screen
-            name="Error"
-            component={ErrorScreen}
+            name="Exit"
+            component={ExitScreen}
             options={{
               animationEnabled: false,
               headerStyle: {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -200,7 +200,7 @@ dependencies {
         exclude group:'com.facebook.flipper'
     }
     implementation project(':react-native-plaid-link-sdk')
-        implementation 'com.plaid.link:sdk-core:3.0.1+'
+        implementation 'com.plaid.link:sdk-core:3.2.0'
         implementation 'com.squareup.okhttp3:okhttp:4.9.0+' 
 
     if (enableHermes) {

--- a/example/components/ExitScreen.tsx
+++ b/example/components/ExitScreen.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Text, View, } from 'react-native';
+import { LinkExit, } from 'react-native-plaid-link-sdk';
 
 var styles = require('./style');
 
-const ErrorScreen = ({ route, navigation }: any) => {
-  const { onerror } = route.params;
-  console.log(onerror);
+const ExitScreen = ({ route, navigation }: any) => {
+  const linkExit : LinkExit = route.params;
+  console.log(linkExit);
   return (
     <View style={{ flex: 1 }}>
       <View style={styles.heading}>
@@ -20,7 +21,7 @@ const ErrorScreen = ({ route, navigation }: any) => {
           {'\n'}
           {'\n'}
           <Text style={(styles.bold, { color: '#000000' })}>
-            {JSON.stringify(onerror)}
+            {JSON.stringify(linkExit)}
           </Text>
         </Text>
       </View>
@@ -28,4 +29,4 @@ const ErrorScreen = ({ route, navigation }: any) => {
   );
 };
 
-export default ErrorScreen;
+export default ExitScreen;

--- a/example/components/HomeScreen.tsx
+++ b/example/components/HomeScreen.tsx
@@ -22,7 +22,7 @@ const HomeScreen = () => {
         </Text>
       </View>
       <View style={styles.bottom}>
-        <PlaidComponent token="link-sandbox-d6f96b38-742f-4a9a-90a5-f121f3445db4" />
+        <PlaidComponent token="link-sandbox-2d968a82-5b16-430f-8986-44bd2a3d992b" />
       </View>
     </View>
   );

--- a/example/components/PlaidLink.tsx
+++ b/example/components/PlaidLink.tsx
@@ -4,8 +4,8 @@ import {
     View,
     StyleSheet,
 } from 'react-native';
-import { PlaidLink, usePlaidEmitter, LinkEvent, LinkExit, LinkSuccess } from 'react-native-plaid-link-sdk';
-import { useNavigation } from '@react-navigation/native';
+import { PlaidLink, usePlaidEmitter, LinkEvent, LinkExit, LinkSuccess, } from 'react-native-plaid-link-sdk';
+import { useNavigation, } from '@react-navigation/native';
 
 const AppButton = (props: any) => {
     return <View style={styles.appButtonContainer}>
@@ -24,11 +24,12 @@ const PlaidComponent = (props: any) => {
                 token: props.token,
             }}
             onSuccess={(success: LinkSuccess) => {
-                navigation.navigate('Success', { onsuccess: success })
+                console.log("ZDS")
                 console.log(success)
+                navigation.navigate('Success', success)
             }}
             onExit={(exit: LinkExit) => {
-                navigation.navigate('Exit', { onerror: exit })
+                navigation.navigate('Exit', exit)
                 console.log(exit)
             }}
         >

--- a/example/components/SuccessScreen.tsx
+++ b/example/components/SuccessScreen.tsx
@@ -7,14 +7,15 @@ import {
   Platform,
   Alert,
 } from 'react-native';
-import { Linking } from 'react-native';
+import { Linking, } from 'react-native';
 import Clipboard from '@react-native-community/clipboard';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { TouchableOpacity, } from 'react-native-gesture-handler';
+import { LinkSuccess, } from 'react-native-plaid-link-sdk';
 
 var styles = require('./style');
 
 const SuccessScreen = ({ route, navigation }: any) => {
-  const { onsuccess } = route.params;
+  const linkSuccess : LinkSuccess  = route.params;
   return (
     <View style={{ flex: 1 }}>
       <View style={styles.heading}>
@@ -48,11 +49,11 @@ const SuccessScreen = ({ route, navigation }: any) => {
           <Text
             style={successStyles.publicKey}
             onLongPress={() => {
-              Clipboard.setString(onsuccess.public_token);
+              Clipboard.setString(linkSuccess.publicToken);
               notifyMessage('Copied to Clipboard');
             }}>
             <Text style={styles.bold}>
-              Public Token: {onsuccess.public_token}
+              Public Token: {linkSuccess.publicToken}
             </Text>
           </Text>
         </TouchableOpacity>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "7.0.0-snapshot5",
+  "version": "7.0.0-snapshot6",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updated the sample app to type the inputs and outputs. Also rename the error screen to the exit screen to match the type that is returned.

This uncovered several bugs on the Android side which were also fixed:

1. Return the writeable map directly instead of putting it in another map under the "data" key"
1. Change gson to not snake case fields
1. set type and subtype to nullable in the account gson adapter