### PR TITLE
Updated sample build.gradle

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -200,8 +200,6 @@ dependencies {
         exclude group:'com.facebook.flipper'
     }
     implementation project(':react-native-plaid-link-sdk')
-        implementation 'com.plaid.link:sdk-core:3.2.0'
-        implementation 'com.squareup.okhttp3:okhttp:4.9.0+' 
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
We no longer need to specify the android sdk version or the okhttp dependency