### PR TITLE
Update types

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -106,7 +106,7 @@ export const useDeepLinkRedirector = () => {
   }, []);
 };
 
-export const PlaidLink = (props: PlaidLinkComponentProps) => {
+export const PlaidLink : React.ReactNode = (props: PlaidLinkComponentProps) => {
   useDeepLinkRedirector();
   return props.children //<Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
 };

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -108,5 +108,5 @@ export const useDeepLinkRedirector = () => {
 
 export const PlaidLink : React.ReactNode = (props: PlaidLinkComponentProps) => {
   useDeepLinkRedirector();
-  return props.children //<Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
+  return <Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
 };

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -11,6 +11,7 @@ import {
   LinkEventListener,
   LinkExit,
   LinkSuccess,
+  PlaidLinkComponentProps,
   PlaidLinkProps,
 } from './Types';
 
@@ -105,7 +106,7 @@ export const useDeepLinkRedirector = () => {
   }, []);
 };
 
-export const PlaidLink = (props: PlaidLinkProps) => {
-  //useDeepLinkRedirector();
+export const PlaidLink = (props: PlaidLinkComponentProps) => {
+  useDeepLinkRedirector();
   return props.children //<Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
 };

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -106,6 +106,6 @@ export const useDeepLinkRedirector = () => {
 };
 
 export const PlaidLink = (props: PlaidLinkProps) => {
-  useDeepLinkRedirector();
-  return <Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
+  //useDeepLinkRedirector();
+  return props.children //<Pressable onPress={() => openLink(props)}>{props.children}</Pressable>;
 };

--- a/Types.ts
+++ b/Types.ts
@@ -383,5 +383,8 @@ export interface PlaidLinkProps {
     publicKeyConfig?: LinkPublicKeyConfiguration
     onSuccess: LinkSuccessListener
     onExit?: LinkExitListener
-    children: React.ReactNode
 }
+
+export type PlaidLinkComponentProps = (PlaidLinkProps & {
+    children: React.ReactNode
+});


### PR DESCRIPTION
Typescript infers different types based on its version which lead to issues on different build systems.  This is avoided by explicitly typing the response.

Also this separates out the children from the `PlaidLinkProps` so that they are required for the component but not for the function