### PR TITLE
Fix verification status deserialization

### DIFF
--- a/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
+++ b/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
@@ -26,7 +26,9 @@ class RNAccountAdapter : JsonSerializer<LinkAccount> {
     val obj = JsonObject().apply {
       addProperty("id", src.id)
       addProperty("name", src.name)
-      addProperty("mask", src.mask)
+      src.mask?.let {
+        addProperty("mask", it)
+      }
       src.verificationStatus?.let { status ->
         context?.serialize(status)?.asJsonObject?.let {
           addProperty("verification_status", it.get("json").asString)

--- a/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
+++ b/android/src/main/java/com/plaid/gson/RNAccountAdapter.kt
@@ -27,8 +27,10 @@ class RNAccountAdapter : JsonSerializer<LinkAccount> {
       addProperty("id", src.id)
       addProperty("name", src.name)
       addProperty("mask", src.mask)
-      context?.serialize(src.verificationStatus)?.asJsonObject?.let {
-        addProperty("verification_status", it.get("json").asString)
+      src.verificationStatus?.let { status ->
+        context?.serialize(status)?.asJsonObject?.let {
+          addProperty("verification_status", it.get("json").asString)
+        }
       }
 
       // Special handling around account subtype


### PR DESCRIPTION
If verification status was null we were serializing it to "null" as a string then trying to convert it to a json object.  Instead we should only serialize the status if it is not null to begin with