### PR TITLE
Add commit hook to align react native version with Android version

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="5.0.2" />
+      android:value="7.0.0-snapshot12" />
   </application>
 
 </manifest>

--- a/check_version_hook.js
+++ b/check_version_hook.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const rn_version = JSON.parse(fs.readFileSync('package.json', 'utf-8'))[
+  'version'
+];
+const android_version = fs
+  .readFileSync('android/src/main/AndroidManifest.xml', 'utf-8')
+  .match(/(?<=value=").*(?=")/)[0];
+
+if (rn_version != android_version) {
+  console.error('Commit failed SDK version mismatch');
+  console.error(
+    'Please ensure package.json and android/src/main/AndroidManifest.xml have the same version',
+  );
+  process.exit(-1);
+}

--- a/check_version_hook.sh
+++ b/check_version_hook.sh
@@ -1,9 +1,0 @@
-# Check for version alignment between RN and Android SDK
-rn_version=$(awk '/"version"/ {print $2;exit}' package.json | tr -d '",')
-android_version=$(awk -F'"' '/android:value/ {print $2}' android/src/main/AndroidManifest.xml)
-
-if [ "${rn_version}" != "$android_version" ]; then
-  echo "Commit failed SDK version mismatch"
-  echo "Please ensure package.json and android/src/main/AndroidManifest.xml have the same version"
-  exit -1
-fi

--- a/check_version_hook.sh
+++ b/check_version_hook.sh
@@ -1,0 +1,9 @@
+# Check for version alignment between RN and Android SDK
+rn_version=$(awk '/"version"/ {print $2;exit}' package.json | tr -d '",')
+android_version=$(awk -F'"' '/android:value/ {print $2}' android/src/main/AndroidManifest.xml)
+
+if [ "${rn_version}" != "$android_version" ]; then
+  echo "Commit failed SDK version mismatch"
+  echo "Please ensure package.json and android/src/main/AndroidManifest.xml have the same version"
+  exit -1
+fi

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "version": "git add -A",
     "postversion": "git push && git push --tags && rm -rf dist/temp",
-    "compile-typescript": "tsc"
+    "compile-typescript": "tsc",
+    "check-version": "bash check_version_hook.sh"
   },
   "keywords": [
     "react-native",
@@ -24,7 +25,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && npm run check-version"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "git add -A",
     "postversion": "git push && git push --tags && rm -rf dist/temp",
     "compile-typescript": "tsc",
-    "check-version": "bash check_version_hook.sh"
+    "check-version": "node check_version_hook.js"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Problem: the react native version hardcoded in the Android SDK was out of date with the current version in `package.json`

Solution: add a pre-commit hook that checks whether both versions are aligned and only allows to commit when that's the case.