### PR TITLE
IOS: Return LinkSuccess in onSuccess

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -64,20 +64,16 @@ export const openLink = async (props: PlaidLinkProps) => {
             props.onExit(data);
           }
         } else {
-          switch (result.metadata.status) {
-            case 'connected':
-              if (props.onSuccess != null) {
-                delete result.metadata.status;
-                props.onSuccess(result);
-              }
-              break;
-            default:
-              if (props.onExit != null) {
-                delete result.metadata.status;
-                props.onExit(result);
-              }
-              break;
+          if (result.publicToken) {
+             if (props.onSuccess != null) {
+               props.onSuccess(result);
+             }
+          } else {
+            if (props.onExit != null) {
+              props.onExit(result);
+            }
           }
+
         }
       },
     );

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -56,29 +56,26 @@ export const openLink = async (props: PlaidLinkProps) => {
   } else {
     NativeModules.RNLinksdk.create(config);
     NativeModules.RNLinksdk.open(
-      (error: LinkError, result: LinkExit & LinkSuccess) => {
-        if (error) {
-          if (props.onExit != null) {
+      (result: LinkSuccess) => {
+        if (props.onSuccess != null) {
+          props.onSuccess(result);
+        }
+      },
+      (error: LinkError, result: LinkExit) => {
+        if (props.onExit != null) {
+          if (error) {
             var data = result || {};
             data.error = error;
             props.onExit(data);
-          }
-        } else {
-          if (result.publicToken) {
-             if (props.onSuccess != null) {
-               props.onSuccess(result);
-             }
           } else {
-            if (props.onExit != null) {
-              props.onExit(result);
-            }
+            props.onExit(result);
           }
-
         }
-      },
+      }
     );
   }
 };
+
 
 export const dismissLink = () => {
   if (Platform.OS === 'ios') {

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -502,8 +502,6 @@ RCT_EXPORT_METHOD(dismiss) {
 + (NSDictionary *)dictionaryFromSuccess:(PLKLinkSuccess *)success {
     PLKSuccessMetadata *metadata = success.metadata;
     return @{
-        // TODO: Remove `status` key.
-        @"status": @"connected",
         @"publicToken": success.publicToken ?: @"",
         @"metadata": @{
           @"linkSessionId": metadata.linkSessionID ?: @"",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Plaid', '~> 2.0.8'
+  s.dependency 'Plaid', '~> 2.0.9'
 end


### PR DESCRIPTION
Changed the approach of piping from the native layer to the JS layer to be more similar to Android, which is to pipe to two listeners from the objective-C layers’ onSuccess and onExit.
Thus, we indirectly rely on Objective C’s type system

Test plan:
LinkSuccess with user_good, pass_good returns in onSuccess
Success:  
```
{
  "metadata": {
    "accounts": [[Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object]],
    "institution": {
      "id": "ins_6",
      "name": "US Bank"
    },
    "linkSessionId": "e26f9ae7-45d3-400f-a953-67438c5e080a",
    "metadataJson": "{<TRUNCATED>"
  },
  "publicToken": "public-sandbox-499010af-7e82-46ca-8725-ece3e823c7f9"
}
```


LinkExit returns in onExit
  Exit:  
```
  {
  "error": {
    "errorCode": "",
    "errorDisplayMessage": "",
    "errorMessage": "",
    "errorType": ""
  },
  "metadata": {
    "institution": {
      "id": "ins_9",
      "name": "Capital One"
    },
    "linkSessionId": "d1b0f07b-bfd3-4e90-ab6f-1fd80116bbfc",
    "metadataJson": "{\"institution\":{\"name\":\"Capital One\",\"institution_id\":\"ins_9\"},\"request_id\":null,\"link_session_id\":\"d1b0f07b-bfd3-4e90-ab6f-1fd80116bbfc\",\"status\":\"requires_credentials\"}",
    "requestId": "",
    "status": "requires_credentials"
  }
}
```