### PR TITLE
change `String` types to `string` for string literals

### DIFF
--- a/Types.ts
+++ b/Types.ts
@@ -236,14 +236,14 @@ export interface LinkSuccess {
 export interface LinkSuccessMetadata {
     institution?: LinkInstitution;
     accounts: LinkAccount[];
-    linkSessionId: String;
-    metadataJson?: String;
+    linkSessionId: string;
+    metadataJson?: string;
 }
 
 export interface LinkAccount {
-    id: String;
-    name?: String;
-    mask?: String;
+    id: string;
+    name?: string;
+    mask?: string;
     type: LinkAccountType;
     subtype: LinkAccountSubtype;
     verificationStatus?: LinkAccountVerificationStatus;
@@ -256,8 +256,8 @@ export enum LinkAccountVerificationStatus {
 }
 
 export interface LinkInstitution {
-    id: String;
-    name: String;
+    id: string;
+    name: string;
 }
 
 export interface LinkExit {
@@ -270,7 +270,7 @@ export interface LinkExitMetadata {
     institution?: LinkInstitution;
     linkSessionId: string;
     requestId: string;
-    metadataJson?: String;
+    metadataJson?: string;
 }
 
 export enum LinkExitMetadataStatus {


### PR DESCRIPTION
Feel free to close if the usage of `String` was intentional