### PR TITLE
Proposal: Add autolinking support

### DIFF
--- a/android/src/main/java/com/plaid/PlaidPackage.java
+++ b/android/src/main/java/com/plaid/PlaidPackage.java
@@ -1,38 +1,30 @@
 package com.plaid;
 
-import java.util.HashMap;
-import java.util.Map;
+import androidx.annotation.NonNull;
 
-import com.facebook.react.TurboReactPackage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.module.model.ReactModuleInfo;
-import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.uimanager.ViewManager;
 
 @SuppressWarnings("unused")
-public class PlaidPackage extends TurboReactPackage {
+public class PlaidPackage implements ReactPackage {
 
+  @NonNull
   @Override
-  public NativeModule getModule(
-      String name, ReactApplicationContext reactContext) {
-    return new PlaidModule(reactContext);
+  public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new PlaidModule(reactContext));
+    return modules;
   }
 
+  @NonNull
   @Override
-  public ReactModuleInfoProvider getReactModuleInfoProvider() {
-    return () -> {
-      Map<String, ReactModuleInfo> map = new HashMap<>();
-      map.put(
-          "PlaidAndroid",
-          new ReactModuleInfo(
-              "PlaidAndroid",
-              "com.reactlibrary.PlaidModule",
-              false,
-              false,
-              true,
-              false,
-              false));
-      return map;
-    };
+  public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+    return Collections.emptyList();
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -199,7 +199,6 @@ dependencies {
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
-    implementation project(':react-native-plaid-link-sdk')
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/example/android/app/src/main/java/com/plaidrndemo/MainApplication.java
+++ b/example/android/app/src/main/java/com/plaidrndemo/MainApplication.java
@@ -28,7 +28,6 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // packages.add(new MyReactNativePackage());
-          packages.add(new PlaidPackage());
           return packages;
         }
 

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,5 +1,3 @@
 rootProject.name = 'plaidRNDemo'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
-include ':react-native-plaid-link-sdk'
-project(':react-native-plaid-link-sdk').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-plaid-link-sdk/android')
 include ':app'


### PR DESCRIPTION
Investigate a community request to support autolinking on Android: https://github.com/plaid/react-native-plaid-link-sdk/issues/299

It seems like react native supports two kind of Android modules: Native Modules and Turbo Modules (still in development). 

As the name implies, Turbo modules are faster to initialize which speeds up cold start of react native apps. However they are still [under development](https://github.com/react-native-community/discussions-and-proposals/issues/40), even though already introduced since react native 0.60.0.

While I couldn't find a conclusive answer on this, it seems like Turbo Modules don't support autolinking ([yet](https://twitter.com/nparashuram/status/1176870431317315584)?). So this means we have to make a choice between either:

- Keep the existing Turbo modules: makes our SDK faster to initialize, but slightly harder to integrate
- Move back to Native modules: makes our SDK slower to initialize, but easier to integrate

This PR follows the [steps to create a Native Module](
https://reactnative.dev/docs/native-modules-android) and makes autolinking work for our react native SDK.

We're looking for community feedback/guidance on how to proceed on this.

Note: interestingly, [Lottie react native](https://github.com/lottie-react-native/lottie-react-native/blob/master/src/android/src/main/java/com/airbnb/android/react/lottie/LottiePackage.java) uses the Native Module