### PR TITLE
Reduce dependency conflicts

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="7.0.0-rc2" />
+      android:value="7.0.0-rc3" />
   </application>
 
 </manifest>

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "react-native": "^0.63.3"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^4.6.1",
-    "prop-types": "^15.7.2"
+    "@typescript-eslint/parser": "^4.6.1"
   },
   "devDependencies": {
     "@react-native-community/eslint-plugin": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "7.0.0-rc2",
+  "version": "7.0.0-rc3",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
   },
   "dependencies": {
     "@typescript-eslint/parser": "^4.6.1",
-    "prop-types": "^15.7.2",
-    "react": "~16.13.1",
-    "react-native": "^0.63.3"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@react-native-community/eslint-plugin": "^1.1.0",
@@ -61,8 +59,8 @@
     "husky": "^3.1.0",
     "lint-staged": "^9.4.2",
     "prettier": "^1.18.2",
-    "react": "^16.8.1",
-    "react-native": "^0.61.3",
+    "react": "~16.13.1",
+    "react-native": "^0.63.3",
     "typescript": "^4.0.3",
     "xyz": "0.5.x"
   }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "react": "~16.13.1",
     "react-native": "^0.63.3"
   },
-  "dependencies": {
-    "@typescript-eslint/parser": "^4.6.1"
-  },
   "devDependencies": {
     "@react-native-community/eslint-plugin": "^1.1.0",
     "@types/jest": "^26.0.14",
@@ -51,6 +48,7 @@
     "@types/react-native": "^0.63.25",
     "@types/react-test-renderer": "^16.9.3",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
+    "@typescript-eslint/parser": "^4.6.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.12.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Plaid",
   "license": "MIT",
   "peerDependencies": {
-    "react": "~16.13.1",
-    "react-native": "^0.63.3"
+    "react": "*",
+    "react-native": ">=0.61"
   },
   "devDependencies": {
     "@react-native-community/eslint-plugin": "^1.1.0",


### PR DESCRIPTION
Convert `react-native` and `react` to be a peer dependency instead of a normal dependency. This will cause build errors on dependency conflicts instead of ending up with two different versions of the same module in the host application.

To learn more about peer dependencies, have a look at [this article](https://medium.com/angular-in-depth/npm-peer-dependencies-f843f3ac4e7f).

On top this also loosens our restrictions on `react-native` and `react` versions, for instance:

```
  "peerDependencies": {
    "react": "*", // Let react-native decide the version
    "react-native": ">=0.61" // released Sept 2019
  },
```

This potentially fixes https://github.com/plaid/react-native-plaid-link-sdk/issues/295

-----------------------------------------

Tested this with a a sample project using a different version of `react-native` and `react`:

- LinkSdkSample: `react: 16.11.0` and `react-native: 0.62.2`
- Plaid RN SDK: `react: 16.13.1` and `react-native: 0.63.3`

When using `7.0.0-rc2`:
```
$ npm ls react 
LinkSdkSample@0.0.1
├── UNMET PEER DEPENDENCY react@16.11.0
└─┬ react-native-plaid-link-sdk@7.0.0-rc2
  └── react@16.13.1
```
This could lead to two versions of react in the same application.

When using `7.0.0-rc3`:
```
LinkSdkSample@0.0.1 /Users/jmols/development/client/products/link-demo/react-native
└── UNMET PEER DEPENDENCY react@16.11.0

npm ERR! peer dep missing: react@~16.13.1, required by react-native-plaid-link-sdk@7.0.0-reacttest1
```
This instead leads to an error instead of two versions of react in the same application

Running Android with `7.0.0-rc3` would yield an error:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find com.facebook.react:react-native:0.63.3.
     Searched in the following locations:
       - file:/Users/jmols/.m2/repository/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
       - file:/Users/jmols/development/client/products/link-demo/react-native/node_modules/react-native/android/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
       - file:/Users/jmols/development/client/products/link-demo/react-native/node_modules/jsc-android/dist/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
       - https://dl.google.com/dl/android/maven2/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
       - https://jcenter.bintray.com/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
       - https://jitpack.io/com/facebook/react/react-native/0.63.3/react-native-0.63.3.pom
     Required by:
         project :app
```