### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/plaid/react-native-plaid-link-sdk.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Plaid', '~> 2.0.9'
 end


### PR DESCRIPTION
### Summary
Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

### Test Plan
Use this branch to install with an app running on Xcode 12.
