### PR TITLE
Add deprecation log

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -38,7 +38,11 @@ export const usePlaidEmitter = (LinkEventListener: LinkEventListener) => {
 
 
 export const openLink = async (props: PlaidLinkProps) => {
+  if (props.tokenConfig == null) {
+    console.log('The public_key is being deprecated. Learn how to upgrade to link_tokens at https://plaid.com/docs/#create-link-token')
+  }
   let config = props.tokenConfig ? props.tokenConfig : props.publicKeyConfig!;
+
   if (Platform.OS === 'android') {
     NativeModules.PlaidAndroid.startLinkActivityForResult(
       JSON.stringify(config),

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -39,7 +39,7 @@ export const usePlaidEmitter = (LinkEventListener: LinkEventListener) => {
 
 export const openLink = async (props: PlaidLinkProps) => {
   if (props.tokenConfig == null) {
-    console.log('The public_key is being deprecated. Learn how to upgrade to link_tokens at https://plaid.com/docs/#create-link-token')
+    console.log('The public_key is being deprecated. Learn how to upgrade to link_tokens at https://plaid.com/docs/link-token-migration-guide/')
   }
   let config = props.tokenConfig ? props.tokenConfig : props.publicKeyConfig!;
 


### PR DESCRIPTION
We used to have a deprecation log for public keys, but accidentally removed that in `7.0.0`.
This PR brings that back.

Tested by opening Link with public key and see warning in console, opening Link with no token yielded no warning.

Triggered by https://github.com/plaid/react-native-plaid-link-sdk/issues/328
