### PR TITLE
updating LinkEventName and LinkError typings

### DIFF
--- a/Types.ts
+++ b/Types.ts
@@ -439,21 +439,21 @@ export interface LinkEventMetadata {
 }
 
 export enum LinkEventName {
-    CLOSE_OAUTH = 'close_oauth',
-    ERROR = 'error',
-    EXIT = 'exit',
-    FAIL_OAUTH = 'fail_oauth',
-    HANDOFF = 'handoff',
-    MATCHED_CONSENT = 'matched_consent',
-    MATCHED_SELECT_INSTITUTION = 'matched_select_institution',
-    OPEN = 'open',
-    OPEN_MY_PLAID = 'open_my_plaid',
-    OPEN_OAUTH = 'open_oauth',
-    SEARCH_INSTITUTION = 'search_institution',
-    SELECT_INSTITUTION = 'select_institution',
-    SUBMIT_CREDENTIALS = 'submit_credentials',
-    SUBMIT_MFA = 'submit_mfa',
-    TRANSITION_VIEW = 'transition_view',
+    CLOSE_OAUTH = 'CLOSE_OAUTH',
+    ERROR = 'ERROR',
+    EXIT = 'EXIT',
+    FAIL_OAUTH = 'FAIL_OAUTH',
+    HANDOFF = 'HANDOFF',
+    MATCHED_CONSENT = 'MATCHED_CONSENT',
+    MATCHED_SELECT_INSTITUTION = 'MATCHED_SELECT_INSTITUTION',
+    OPEN = 'OPEN',
+    OPEN_MY_PLAID = 'OPEN_MY_PLAID',
+    OPEN_OAUTH = 'OPEN_OAUTH',
+    SEARCH_INSTITUTION = 'SEARCH_INSTITUTION',
+    SELECT_INSTITUTION = 'SELECT_INSTITUTION',
+    SUBMIT_CREDENTIALS = 'SUBMIT_CREDENTIALS',
+    SUBMIT_MFA = 'SUBMIT_MFA',
+    TRANSITION_VIEW = 'TRANSITION_VIEW',
 }
 
 export enum LinkEventViewName {

--- a/Types.ts
+++ b/Types.ts
@@ -291,7 +291,7 @@ export interface LinkError {
     errorCode: LinkErrorCode;
     errorType: LinkErrorType;
     errorMessage: string;
-    errorDisplayMessage?: string;
+    displayMessage?: string;
     errorJson?: string;
 }
 

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -598,7 +598,7 @@ RCT_EXPORT_METHOD(dismiss) {
         @"errorType": [self errorTypeStringFromError:error] ?: @"",
         @"errorCode": [self errorCodeStringFromError:error] ?: @"",
         @"errorMessage": [self errorMessageFromError:error] ?: @"",
-        @"errorDisplayMessage": [self errorDisplayMessageFromError:error] ?: @"",
+        @"displayMessage": [self errorDisplayMessageFromError:error] ?: @"",
     };
 }
 


### PR DESCRIPTION
Addresses part of the comment on [326](https://github.com/plaid/react-native-plaid-link-sdk/issues/326) and the fact that the `LinkEventName` typing currently has lowercase fields (though the actual `LinkEvent` object has an uppercase `eventName` field) 