### PR TITLE
(Change base branch to main once bridgePublicTokens lands) – Ensure the dismissal logic is only invoked once

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -37,6 +37,7 @@ NSString* const kRNLinkKitLinkTokenPrefix = @"link-";
 NSString* const kRNLinkKitItemAddTokenPrefix = @"item-add-";
 NSString* const kRNLinkKitPaymentTokenPrefix = @"payment";
 NSString* const kRNLinkKitDepositSwitchTokenPrefix = @"deposit-switch-";
+NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 
 @interface RNLinksdk ()
 @property (nonatomic, strong) id<PLKHandler> linkHandler;
@@ -285,12 +286,15 @@ RCT_EXPORT_METHOD(dismiss) {
     BOOL isPaymentToken = [tokenInput hasPrefix:kRNLinkKitPaymentTokenPrefix];
     BOOL isItemAddToken = [tokenInput hasPrefix:kRNLinkKitItemAddTokenPrefix];
     BOOL isDepositSwitchToken = [tokenInput hasPrefix:kRNLinkKitDepositSwitchTokenPrefix];
+    BOOL isPublicToken = [tokenInput hasPrefix:kRNLinkKitPublicTokenPrefix];
     if (isPaymentToken) {
         token = [PLKLinkPublicKeyConfigurationToken createWithPaymentToken:tokenInput publicKey:key];
     } else if (isItemAddToken) {
         token = [PLKLinkPublicKeyConfigurationToken createWithPublicToken:tokenInput publicKey:key];
     } else if (isDepositSwitchToken) {
         token = [PLKLinkPublicKeyConfigurationToken createWithDepositSwitchToken:tokenInput publicKey:key];
+    } else if (isPublicToken) {
+        token = [PLKLinkPublicKeyConfigurationToken createWithPublicToken:tokenInput publicKey:key];
     } else {
         token = [PLKLinkPublicKeyConfigurationToken createWithPublicKey:key];
     }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -95,7 +95,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
         // If PLKSuccessMetadata responds to neither, swizzling cannot fix this
         if (respondsToNeither) {
             NSString *githubIssueURLString = @"https://github.com/plaid/react-native-plaid-link-sdk/issues/new?assignees=&labels=&template=bug_report.md&title=";
-            NSAssert(false, @"%@ does not respond to correctly spelled %@ or legacy, typo %@. This is a bug in either react-native-plaid-link-sdk, or LinkKit. Please file an issue at: %@", NSStringFromClass(targetClass), NSStringFromSelector(correctSel), NSStringFromSelector(typoSel), githubIssueURLString);
+            NSAssert(NO, @"%@ does not respond to correctly spelled %@ or legacy, typo %@. This is a bug in either react-native-plaid-link-sdk, or LinkKit. Please file an issue at: %@", NSStringFromClass(targetClass), NSStringFromSelector(correctSel), NSStringFromSelector(typoSel), githubIssueURLString);
             return;
         }
 
@@ -146,13 +146,13 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)startObserving {
-    self.hasObservers = true;
+    self.hasObservers = YES;
     [super startObserving];
 }
 
 - (void)stopObserving {
     [super stopObserving];
-    self.hasObservers = false;
+    self.hasObservers = NO;
 }
 
 RCT_EXPORT_METHOD(continueFromRedirectUriString:(NSString *)redirectUriString) {
@@ -218,7 +218,7 @@ RCT_EXPORT_METHOD(create:(NSDictionary*)configuration) {
                                                                 onSuccessHandler:onSuccess];
         config.onEvent = onEvent;
         config.onExit = onExit;
-           NSError *creationError = nil;
+        NSError *creationError = nil;
         self.linkHandler = [PLKPlaid createWithLinkPublicKeyConfiguration:config
                                                                     error:&creationError];
         self.creationError = creationError;
@@ -238,7 +238,7 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)onSuccess :(RCTResponseSenderBloc
 
         __weak typeof(self) weakSelf = self;
         void(^presentationHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
-            [weakSelf.presentingViewController presentViewController:linkViewController animated:true completion:nil];
+            [weakSelf.presentingViewController presentViewController:linkViewController animated:YES completion:nil];
         };
         void(^dismissalHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
             [weakSelf dismiss];
@@ -253,10 +253,6 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)onSuccess :(RCTResponseSenderBloc
 RCT_EXPORT_METHOD(dismiss) {
     [self.presentingViewController dismissViewControllerAnimated:YES
                                                       completion:nil];
-    [self cleanupSession];
-}
-
-- (void)cleanupSession {
     self.presentingViewController = nil;
     self.linkHandler = nil;
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -251,12 +251,9 @@ RCT_EXPORT_METHOD(open:(RCTResponseSenderBlock)onSuccess :(RCTResponseSenderBloc
 }
 
 RCT_EXPORT_METHOD(dismiss) {
-    [self dismissLinkViewController];
+    [self.presentingViewController dismissViewControllerAnimated:YES
+                                                      completion:nil];
     [self cleanupSession];
-}
-
-- (void)dismissLinkViewController {
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)cleanupSession {


### PR DESCRIPTION
Using the new dismissalHandler API, we can keep the existing cleanup code in -dismiss while preventing another call to dismissing the view controller from being initiated by LinkKit.

Closes #227