### PR TITLE
Remove deprecated version of tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,5 @@
     "react-native": "^0.63.3",
     "typescript": "^4.2.4",
     "xyz": "0.5.x"
-  },
-  "dependencies": {
-    "tsc": "^1.20150623.0"
   }
 }


### PR DESCRIPTION
The package.json file for this library contains a non-dev dependency called [tsc](https://www.npmjs.com/package/tsc), which unfortunately clobbers the tsc CLI that's included with the [typescript](https://www.npmjs.com/package/typescript) package.

### How I tested

- [x] verify that `yarn compile-typescript` still works without it