### PR TITLE
RN: Check for <React/RCTBridgeModule> instead of "RCTBridgeModule"

### DIFF
--- a/ios/RNLinksdk.h
+++ b/ios/RNLinksdk.h
@@ -1,10 +1,10 @@
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#else
+#import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #endif
 
 @interface RNLinksdk : RCTEventEmitter <RCTBridgeModule>


### PR DESCRIPTION
RN: Check for <React/RCTBridgeModule> instead

https://github.com/plaid/react-native-plaid-link-sdk/issues/436