### PR TITLE
Add support for autolinking

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dist/**/*",
     "android/**/*",
     "ios/**/*",
-    "react-native-plaid-link-sdk.podspec"
+    "react-native-plaid-link-sdk.podspec",
+    "react-native.config.js"
   ],
   "scripts": {
     "lint": "eslint \"./**/*.{js,jsx}\" --fix",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+module.exports = {
+  dependency: {
+    platforms: {
+      ios: {
+        podspecPath: path.join(
+          __dirname,
+          'react-native-plaid-link-sdk.podspec',
+        ),
+      },
+      android: {
+        packageImportPath: 'import com.plaid.PlaidPackage;',
+        packageInstance: 'new PlaidPackage()',
+      },
+    },
+  },
+};


### PR DESCRIPTION
This replace all the manual steps to link the package on iOS and Android. If this PR is accepted, we could remove the steps in the README.