### PR TITLE
Add `BANK_INCOME_INSIGHTS_COMPLETED` event

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -752,6 +752,8 @@ RCT_EXPORT_METHOD(dismiss) {
     switch (eventName.value) {
         case PLKEventNameValueNone:
             return @"";
+        case PLKEventNameValueBankIncomeInsightsCompleted:
+            return @"BANK_INCOME_INSIGHTS_COMPLETED";
         case PLKEventNameValueCloseOAuth:
             return @"CLOSE_OAUTH";
         case PLKEventNameValueError:


### PR DESCRIPTION
This adds mapping for the `BANK_INCOME_INSIGHTS_COMPLETED` event from the iOS 2.3.2 release