### PR TITLE
Make iOS version explicit

### DIFF
--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 2.3.2'
+  s.dependency 'Plaid', '2.3.2'
 end


### PR DESCRIPTION
This PR ensures that going forward, an explicit version of the iOS Link SDK is associated with each version of the React Native Link SDK