### PR TITLE
Add most gitignore records to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,51 @@
 # Example app
 example/
+
+# .gitignore is ignored when .npmignore is provided
+
+# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# This points at internal endpoints which shouldn't be exposed to the public repo.
+package-lock.json
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+      
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore


### PR DESCRIPTION
If `.npmignore` is used, `.gitignore` is ignored by npm. `android/build` is published on npm. This change will fix that.

It'll reduce the npm package size from 9MB to less than 180KB