### PR TITLE
Add iOS OAuth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,45 @@ followed by
 3. In Xcode, in the project navigator, select your project. Add `libRNLinksdk.a` to your project's `Build Phases` ▶ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 
+### OAuth Requirements
+
+For iOS OAuth to work, specific requirements must be met.
+* Redirect URIs must be registered, and set up as universal links ([docs](https://plaid.com/docs/link/ios/#register-your-redirect-uri))
+* Deep linking must be set up in the application delegate class (see code sample below)
+* The exported `useDeepLinkRedirector` method must be invoked. If you are using the `PlaidLink` component it is invoked automatically, but if you are calling `openLink` programatically you must invoke `useDeepLinkRedirector`.
+
+```objective-c
+#import "AppDelegate.h"
+...
+#import <React/RCTLinkingManager.h>
+
+...
+
+@implementation AppDelegate
+
+...
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
+}
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
+ return [RCTLinkingManager application:application
+                  continueUserActivity:userActivity
+                    restorationHandler:restorationHandler];
+}
+
+...
+
+@end
+```
+
+
 ## Android setup
 [Autolinking][autolinking]  unfortunately isn't supported for Android, because the SDK makes use of [TurboModules][turbomodules] to speed up app cold starts. Have a look at [#306](https://github.com/plaid/react-native-plaid-link-sdk/pull/306) for more context.
 

--- a/example/ios/plaidRNDemo/AppDelegate.m
+++ b/example/ios/plaidRNDemo/AppDelegate.m
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
 
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
@@ -53,6 +54,22 @@ static void InitializeFlipper(UIApplication *application) {
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
+}
+
+// Only if your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
+ return [RCTLinkingManager application:application
+                  continueUserActivity:userActivity
+                    restorationHandler:restorationHandler];
 }
 
 @end


### PR DESCRIPTION
Our docs were not explicit about how to set up deep link handling, which is necessary for OAuth bank connections