### PR TITLE
add missing LinkEventName for plaid events BANK_INCOME_INSIGHTS_COMPLETED

### DIFF
--- a/Types.ts
+++ b/Types.ts
@@ -450,6 +450,7 @@ export interface LinkEventMetadata {
 }
 
 export enum LinkEventName {
+    BANK_INCOME_INSIGHTS_COMPLETED = "BANK_INCOME_INSIGHTS_COMPLETED",
     CLOSE_OAUTH = 'CLOSE_OAUTH',
     ERROR = 'ERROR',
     EXIT = 'EXIT',


### PR DESCRIPTION
extends support for https://plaid.com/docs/link/react-native/#link-react_native-onevent-eventName-BANK-INCOME-INSIGHTS-COMPLETED, which has been elevated to a stable event.