### PR TITLE
Remove '+' from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
     repositories {
         mavenLocal()
-+       mavenCentral()
+        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
In PR #490, a plus was added in front of `mavenCentral()`. This commit removes the plus.
I would greatly appreciate it if this gets merged and released ASAP, since no android app can be built with `jcenter()`.