### PR TITLE
replaced deprecated removeEventListener() with remove()

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -99,10 +99,10 @@ export const useDeepLinkRedirector = () => {
   };
 
   useEffect(() => {
-    Linking.addEventListener('url', _handleListenerChange);
+    const listener = Linking.addEventListener('url', _handleListenerChange);
 
     return function cleanup() {
-      Linking.removeEventListener('url', _handleListenerChange);
+      listener.remove();
     };
   }, []);
 };


### PR DESCRIPTION
`removeEventListener` is deprecated and now it's removed with RN 0.71.
Besides it causes a problem on unmounting the component:

`Warning: Internal React error: Attempted to capture a commit phase error inside a detached tree.`