### PR TITLE
removed kotlin-gradle-plugin versioning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,6 @@ allprojects {
 
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         mavenCentral()
@@ -21,7 +20,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10'
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="8.0.1" />
+      android:value="8.0.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-return @"8.0.1"; // SDK_VERSION
+return @"8.0.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
removed `org.jetbrains.kotlin:kotlin-gradle-plugin` versioning on `build.gradle` which was causing mismatch versions on RN v0.71.0

![Screen Shot 2023-01-15 at 21 37 58](https://user-images.githubusercontent.com/4017312/212560467-f0450daf-8b4d-4793-bf6d-7d96fa9902e9.png)
