### PR TITLE
replace deprecated Linking.removeEventListener with remove

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -99,10 +99,10 @@ export const useDeepLinkRedirector = () => {
   };
 
   useEffect(() => {
-    Linking.addEventListener('url', _handleListenerChange);
+    const listener = Linking.addEventListener('url', _handleListenerChange);
 
     return function cleanup() {
-      Linking.removeEventListener('url', _handleListenerChange);
+      listener.remove();
     };
   }, []);
 };


### PR DESCRIPTION
@wkiefer Thanks for v9.0.0 release!

`Linking.removeEventListener` was deprecated in RN 0.65 and completely removed in RN 0.71.
So `Linking.removeEventListener` is `undefined` always and thus listener is not unsubscribed when close page. Also this introduces console error.

**So it would be good to add this fix to v9 next version. (i.e. v9.0.1)**

![console](https://user-images.githubusercontent.com/108292595/214815052-5195eaa1-9b7b-4c34-9ea7-5ba8bad89bc0.png)
