### PR TITLE
update kotlin graddle plugin to supports rn 0.71

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ allprojects {
 
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
@@ -21,7 +21,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="9.0.1" />
+      android:value="9.0.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-return @"9.0.1"; // SDK_VERSION
+return @"9.0.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
<h1 align="center">
  <img alt="Testing" src="https://user-images.githubusercontent.com/4017312/212560467-f0450daf-8b4d-4793-bf6d-7d96fa9902e9.png" />
</h1>


kotlin gradle plugin is deprecated for rn 0.71

