### PR TITLE
[iOS] Fix Compile Issue

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -160,7 +160,7 @@ RCT_EXPORT_METHOD(continueFromRedirectUriString:(NSString *)redirectUriString) {
     NSURL *receivedRedirectUri = (id)redirectUriString == [NSNull null] ? nil : [NSURL URLWithString:redirectUriString];
 
     if (receivedRedirectUri && self.linkHandler) {
-        [self.linkHandler resumeAfterTermination:receivedRedirectUri];
+        [self.linkHandler continueWithRedirectUri:receivedRedirectUri];
     }
 }
 


### PR DESCRIPTION
`resumeAfterTermination` isn't available in LinkKit `4.1.0` 

<img width="1086" alt="Screen Shot 2023-03-16 at 16 13 10" src="https://user-images.githubusercontent.com/122908338/225772801-845f5f45-4dcf-4c1c-936d-c5ff7280a3dd.png">

So we need to call `[self.linkHandler continueWithRedirectUri:receivedRedirectUri];`