### PR TITLE
Remove deprecated android extensions plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,6 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"
 
 android {
     compileSdkVersion 31


### PR DESCRIPTION
Resolves this warning which appears when running on android:

```
> Configure project :react-native-plaid-link-sdk
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
```
