### PR TITLE
Remove unnecessary Podfile step from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,8 @@ npm install --save react-native-plaid-link-sdk
 For a sample app demonstrating a minimal integration with this SDK, see the [Tiny Quickstart (React Native)](https://github.com/plaid/tiny-quickstart/tree/main/react_native). For a full guide and migration guides please vist our [docs][plaid_rndocs].
 
 ## iOS setup
-Add `Plaid` to your project’s Podfile as follows (likely located at `ios/Podfile`). The latest version is ![version](https://img.shields.io/cocoapods/v/Plaid).
 
-```sh
-pod 'Plaid', '~> <insert latest version>'
-```
-
-Then install your cocoapods dependencies:
+Install your cocoapods dependencies:
 
 ```sh
 (cd ios && pod install)


### PR DESCRIPTION
The pod version is automatically parsed by Cocoapods from the `.podspec` file.