### PR TITLE
Fix iOS/Android Event Metadata key formatting

### DIFF
--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -621,7 +621,6 @@ RCT_EXPORT_METHOD(dismiss) {
         @"subtype": [self subtypeNameForAccountSubtype:account.subtype] ?: @"",
         @"type": [self typeNameForAccountSubtype:account.subtype] ?: @"",
         @"verificationStatus": [self stringForVerificationStatus:account.verificationStatus] ?: @"",
-        @"verification_status": [self stringForVerificationStatus:account.verificationStatus] ?: @"",
     };
 }
 
@@ -682,18 +681,13 @@ RCT_EXPORT_METHOD(dismiss) {
 + (NSDictionary *)dictionaryFromError:(PLKExitError *)error {
     return @{
         @"errorType": [self errorTypeStringFromError:error] ?: @"",
-        @"error_type": [self errorTypeStringFromError:error] ?: @"",
         @"errorCode": [self errorCodeStringFromError:error] ?: @"",
-        @"error_code": [self errorCodeStringFromError:error] ?: @"",
         @"errorMessage": [self errorMessageFromError:error] ?: @"",
-        @"error_message": [self errorMessageFromError:error] ?: @"",
         // errorDisplayMessage is the deprecated name for displayMessage, both have to be populated
         // until errorDisplayMessage is fully removed to avoid breaking the API
         @"errorDisplayMessage": [self errorDisplayMessageFromError:error] ?: @"",
-        @"error_display_message": [self errorDisplayMessageFromError:error] ?: @"",
         @"displayMessage": [self errorDisplayMessageFromError:error] ?: @"",
-        @"display_message": [self errorDisplayMessageFromError:error] ?: @"",
-        @"error_json": error.userInfo[kPLKExitErrorRawJSONKey] ?: @"",
+        @"errorJson": error.userInfo[kPLKExitErrorRawJSONKey] ?: @"",
     };
 }
 

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -592,9 +592,13 @@ RCT_EXPORT_METHOD(dismiss) {
         @"publicToken": success.publicToken ?: @"",
         @"metadata": @{
           @"linkSessionId": metadata.linkSessionID ?: @"",
+          @"link_session_id": metadata.linkSessionID ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
+          @"institution_id": institution.ID ?: @"",
+          @"institution_name": metadata.institution.name ?: @"",
           @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts] ?: @"",
           @"metadataJson": metadata.metadataJSON ?: @"",
+          @"metadata_json": metadata.metadataJSON ?: @"",
       },
     };
 }
@@ -617,6 +621,7 @@ RCT_EXPORT_METHOD(dismiss) {
         @"subtype": [self subtypeNameForAccountSubtype:account.subtype] ?: @"",
         @"type": [self typeNameForAccountSubtype:account.subtype] ?: @"",
         @"verificationStatus": [self stringForVerificationStatus:account.verificationStatus] ?: @"",
+        @"verification_status": [self stringForVerificationStatus:account.verificationStatus] ?: @"",
     };
 }
 
@@ -677,12 +682,18 @@ RCT_EXPORT_METHOD(dismiss) {
 + (NSDictionary *)dictionaryFromError:(PLKExitError *)error {
     return @{
         @"errorType": [self errorTypeStringFromError:error] ?: @"",
+        @"error_type": [self errorTypeStringFromError:error] ?: @"",
         @"errorCode": [self errorCodeStringFromError:error] ?: @"",
+        @"error_code": [self errorCodeStringFromError:error] ?: @"",
         @"errorMessage": [self errorMessageFromError:error] ?: @"",
+        @"error_message": [self errorMessageFromError:error] ?: @"",
         // errorDisplayMessage is the deprecated name for displayMessage, both have to be populated
         // until errorDisplayMessage is fully removed to avoid breaking the API
         @"errorDisplayMessage": [self errorDisplayMessageFromError:error] ?: @"",
+        @"error_display_message": [self errorDisplayMessageFromError:error] ?: @"",
         @"displayMessage": [self errorDisplayMessageFromError:error] ?: @"",
+        @"display_message": [self errorDisplayMessageFromError:error] ?: @"",
+        @"error_json": error.userInfo[PLKExitErrorRawJSONKey] ?: @"",
     };
 }
 
@@ -691,20 +702,33 @@ RCT_EXPORT_METHOD(dismiss) {
 
     return @{
         @"eventName": [self stringForEventName:event.eventName] ?: @"",
+        @"event_name": [self stringForEventName:event.eventName] ?: @"",
         @"metadata": @{
             @"errorType": [self errorTypeStringFromError:metadata.error] ?: @"",
+            @"error_type": [self errorTypeStringFromError:metadata.error] ?: @"",
             @"errorCode": [self errorCodeStringFromError:metadata.error] ?: @"",
+            @"error_code": [self errorCodeStringFromError:metadata.error] ?: @"",
             @"errorMessage": [self errorMessageFromError:metadata.error] ?: @"",
+            @"error_message": [self errorMessageFromError:metadata.error] ?: @"",
             @"exitStatus": [self stringForExitStatus:metadata.exitStatus] ?: @"",
+            @"exit_status": [self stringForExitStatus:metadata.exitStatus] ?: @"",
             @"institutionId": metadata.institutionID ?: @"",
+            @"institution_id": metadata.institutionID ?: @"",
             @"institutionName": metadata.institutionName ?: @"",
+            @"institution_name": metadata.institutionName ?: @"",
             @"institutionSearchQuery": metadata.institutionSearchQuery ?: @"",
+            @"institution_search_query": metadata.institutionSearchQuery ?: @"",
             @"linkSessionId": metadata.linkSessionID ?: @"",
+            @"link_session_id": metadata.linkSessionID ?: @"",
             @"mfaType": [self stringForMfaType:metadata.mfaType] ?: @"",
+            @"mfa_type": [self stringForMfaType:metadata.mfaType] ?: @"",
             @"requestId": metadata.requestID ?: @"",
+            @"request_id": metadata.requestID ?: @"",
             @"timestamp": [self iso8601StringFromDate:metadata.timestamp] ?: @"",
             @"viewName": [self stringForViewName:metadata.viewName] ?: @"",
+            @"view_name": [self stringForViewName:metadata.viewName] ?: @"",
             @"metadataJson": metadata.metadataJSON ?: @"",
+            @"metadata_json": metadata.metadataJSON ?: @"",
         },
     };
 }
@@ -955,9 +979,14 @@ RCT_EXPORT_METHOD(dismiss) {
         @"metadata": @{
           @"status": [self stringForExitStatus:metadata.status] ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
+          @"institution_id": institution.ID ?: @"",
+          @"institution_name": metadata.institution.name ?: @"",
           @"requestId": metadata.requestID ?: @"",
+          @"request_id": metadata.requestID ?: @"",
           @"linkSessionId": metadata.linkSessionID ?: @"",
+          @"link_session_id": metadata.linkSessionID ?: @"",
           @"metadataJson": metadata.metadataJSON ?: @"",
+          @"metadata_json": metadata.metadataJSON ?: @"",
         },
     };
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -696,7 +696,6 @@ RCT_EXPORT_METHOD(dismiss) {
 
     return @{
         @"eventName": [self stringForEventName:event.eventName] ?: @"",
-        @"event_name": [self stringForEventName:event.eventName] ?: @"",
         @"metadata": @{
             @"errorType": [self errorTypeStringFromError:metadata.error] ?: @"",
             @"error_type": [self errorTypeStringFromError:metadata.error] ?: @"",

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -968,14 +968,9 @@ RCT_EXPORT_METHOD(dismiss) {
         @"metadata": @{
           @"status": [self stringForExitStatus:metadata.status] ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
-          @"institution_id": metadata.institution.ID ?: @"",
-          @"institution_name": metadata.institution.name ?: @"",
           @"requestId": metadata.requestID ?: @"",
-          @"request_id": metadata.requestID ?: @"",
           @"linkSessionId": metadata.linkSessionID ?: @"",
-          @"link_session_id": metadata.linkSessionID ?: @"",
           @"metadataJson": metadata.metadataJSON ?: @"",
-          @"metadata_json": metadata.metadataJSON ?: @"",
         },
     };
 }

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -594,7 +594,7 @@ RCT_EXPORT_METHOD(dismiss) {
           @"linkSessionId": metadata.linkSessionID ?: @"",
           @"link_session_id": metadata.linkSessionID ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
-          @"institution_id": institution.ID ?: @"",
+          @"institution_id": metadata.institution.ID ?: @"",
           @"institution_name": metadata.institution.name ?: @"",
           @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts] ?: @"",
           @"metadataJson": metadata.metadataJSON ?: @"",
@@ -693,7 +693,7 @@ RCT_EXPORT_METHOD(dismiss) {
         @"error_display_message": [self errorDisplayMessageFromError:error] ?: @"",
         @"displayMessage": [self errorDisplayMessageFromError:error] ?: @"",
         @"display_message": [self errorDisplayMessageFromError:error] ?: @"",
-        @"error_json": error.userInfo[PLKExitErrorRawJSONKey] ?: @"",
+        @"error_json": error.userInfo[kPLKExitErrorRawJSONKey] ?: @"",
     };
 }
 
@@ -979,7 +979,7 @@ RCT_EXPORT_METHOD(dismiss) {
         @"metadata": @{
           @"status": [self stringForExitStatus:metadata.status] ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
-          @"institution_id": institution.ID ?: @"",
+          @"institution_id": metadata.institution.ID ?: @"",
           @"institution_name": metadata.institution.name ?: @"",
           @"requestId": metadata.requestID ?: @"",
           @"request_id": metadata.requestID ?: @"",

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -683,7 +683,6 @@ RCT_EXPORT_METHOD(dismiss) {
         // until errorDisplayMessage is fully removed to avoid breaking the API
         @"errorDisplayMessage": [self errorDisplayMessageFromError:error] ?: @"",
         @"displayMessage": [self errorDisplayMessageFromError:error] ?: @"",
-        @"errorJson": error.userInfo[kPLKExitErrorRawJSONKey] ?: @"",
     };
 }
 

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -592,13 +592,9 @@ RCT_EXPORT_METHOD(dismiss) {
         @"publicToken": success.publicToken ?: @"",
         @"metadata": @{
           @"linkSessionId": metadata.linkSessionID ?: @"",
-          @"link_session_id": metadata.linkSessionID ?: @"",
           @"institution": [self dictionaryFromInstitution:metadata.institution] ?: @"",
-          @"institution_id": metadata.institution.ID ?: @"",
-          @"institution_name": metadata.institution.name ?: @"",
           @"accounts": [self accountsDictionariesFromAccounts:metadata.accounts] ?: @"",
           @"metadataJson": metadata.metadataJSON ?: @"",
-          @"metadata_json": metadata.metadataJSON ?: @"",
       },
     };
 }


### PR DESCRIPTION
This PR resolves the issue where `PLKLinkEvent` on iOS have camelCase keys while Android has snake_case. To prevent a breaking change both keys are added to the metadata dictionary on iOS. We can deprecate the camelCase keys in the next major release.


**OLD IOS EVENT DATA**

```json
{
   "eventName":"TRANSITION_VIEW",
   "metadata":{
      "errorCode":"",
      "errorMessage":"",
      "errorType":"",
      "exitStatus":"",
      "institutionId":"",
      "institutionName":"",
      "institutionSearchQuery":"",
      "linkSessionId":"84a32fb9-67da-4df8-966a-40387c20fd71",
      "metadataJson":"",
      "mfaType":"",
      "requestId":"WUxYDxxmwW8FaIJ",
      "timestamp":"2023-05-04T17:57:57.888Z",
      "viewName":"CONSENT"
   }
}
```

**NEW IOS EVENT DATA**

```json
{
   "eventName":"TRANSITION_VIEW",
   "metadata":{
      "errorCode":"",
      "errorMessage":"",
      "errorType":"",
      "error_code":"",
      "error_message":"",
      "error_type":"",
      "exitStatus":"",
      "exit_status":"",
      "institutionId":"",
      "institutionName":"",
      "institutionSearchQuery":"",
      "institution_id":"",
      "institution_name":"",
      "institution_search_query":"",
      "linkSessionId":"0ef74c02-3298-4e68-8d96-2c48c664c743",
      "link_session_id":"0ef74c02-3298-4e68-8d96-2c48c664c743",
      "metadataJson":"",
      "metadata_json":"",
      "mfaType":"",
      "mfa_type":"",
      "requestId":"8wSqujuNJ6XNIr4",
      "request_id":"8wSqujuNJ6XNIr4",
      "timestamp":"2023-05-04T21:37:59.521Z",
      "viewName":"CONSENT",
      "view_name":"CONSENT"
   }
}
```

**CURRENT ANDROID EVENT DATA**

```json
{
   "eventName":"TRANSITION_VIEW",
   "metadata":{
      "error_code":"",
      "error_message":"",
      "error_type":"",
      "exit_status":"",
      "institution_id":"",
      "institution_name":"",
      "institution_search_query":"",
      "link_session_id":"5ab8c2d1-35db-44c7-b4e3-d53771ed5477",
      "metadata_json":"",
      "mfa_type":"",
      "request_id":"joLIxGnRnu5maa3",
      "timestamp":"2023-05-04T21:41:09.967Z",
      "view_name":"CONSENT"
   }
}
```