### PR TITLE
[Release] - 10.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ When upgrading from a previous major version of this library, see the following 
 # Version compatibility
 | React Native SDK | Android SDK | iOS SDK | Status |
 |---|---|---|---|
-| 10.2.0 | [3.12.0+]     | >=4.3.0  |  Active, supports Xcode 14 |
-| 10.1.0 | [3.11.0+]     | >=4.2.0  |  Active, supports Xcode 14 |
+| 10.3.0 | [3.12.1+]     | >=4.3.0  |  Active, supports Xcode 14 |
+| 10.2.0 | [3.12.0+]     | >=4.3.0  |  Deprecated, supports Xcode 14 |
+| 10.1.0 | [3.11.0+]     | >=4.2.0  |  Deprecated, supports Xcode 14 |
 | 10.0.0 | [3.10.1+]     | >=4.1.0  |  Deprecated, supports Xcode 14 |
 | 9.x.x  | [3.10.1+]     | >=4.1.0  |  Deprecated, supports Xcode 14 |
 | 8.x.x  | [3.10.1+]     | >=3.1.0  |  Deprecated, supports Xcode 14 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,7 +64,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:3.12.0"
+    implementation "com.plaid.link:sdk-core:3.12.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="10.2.0" />
+      android:value="10.3.0" />
   </application>
 
 </manifest>

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.71.7",
-    "react-native-plaid-link-sdk": "^10.2.0"
+    "react-native-plaid-link-sdk": "^10.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"10.2.0"; // SDK_VERSION
+    return @"10.3.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -64,6 +64,6 @@
     "xyz": "0.5.x"
   },
   "dependencies": {
-    "react-native-plaid-link-sdk": "^10.2.0"
+    "react-native-plaid-link-sdk": "^10.3.0"
   }
 }


### PR DESCRIPTION
- Update Android SDK to [3.12.1](https://github.com/plaid/plaid-link-android/releases/tag/v3.12.1).
- [Update Example App](https://github.com/plaid/react-native-plaid-link-sdk/pull/533).
- [Fix event metadata JSON key inconsistency between iOS & Android](https://github.com/plaid/react-native-plaid-link-sdk/pull/532).