### PR TITLE
[Release] - 10.5.0

### DIFF
--- a/.github/workflows/build_test_ios.yml
+++ b/.github/workflows/build_test_ios.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Install pod dependencies
-        run: cd example/ios && bundle install && bundle exec pod install && cd ../
+        run: cd example/ios && bundle install && bundle exec pod update && cd ../
 
       - name: Install the Apple certificate and provisioning profile
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 #### Changes
 
 - Update iOS Native SDK.
-- Add support
+- Add support to present Link full screen. `PlaidLinkProps` not supports passing a `LinkIOSPresentationStyle`. Pass `FULL_SCREEN` to present Link full screen instead of as a modal. For more information checkout the [pull-request](https://github.com/plaid/react-native-plaid-link-sdk/pull/543).
 
 ### Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # RELEASES
 
+## LinkKit V10.4.0 — 2023-08-08
+
+### React Native
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |
+
+#### Changes
+
+- Update iOS Native SDK.
+- Add support
+
+### Android
+
+[Android SDK 3.13.2](https://github.com/plaid/plaid-link-android/releases/tag/v3.13.2)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+
+
+#### Changes
+
+- Changed LinkRedirectActivity theme from Material to MaterialComponents.
+
+### iOS
+
+[iOS SDK 4.5.1](https://github.com/plaid/plaid-link-ios/releases/tag/4.5.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 14.0 |
+| iOS | >= 11.0 |
+
+#### Changes
+
+- Add identityVerificationPendingReviewSession event name.
+- Bug fixes.
+
 ## LinkKit V10.4.0 — 2023-06-13
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ You can also use the `usePlaidEmitter` hook in react functional components:
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
-| 10.4.0            | >= 0.66.0                | [3.12.2+]   | 21                  | 33                     | >=4.4.0 |  11.0           | Active, supports Xcode 14 |
+| 10.5.0            | >= 0.66.0                | [3.12.2+]   | 21                  | 33                     | >=4.5.1 |  11.0           | Active, supports Xcode 14     |
+| 10.4.0            | >= 0.66.0                | [3.12.2+]   | 21                  | 33                     | >=4.4.0 |  11.0           | Deprecated, supports Xcode 14 |
 | 10.3.0            | >= 0.66.0                | [3.12.1+]   | 21                  | 33                     | >=4.3.0 |  11.0           | Deprecated, supports Xcode 14 |
 | 10.2.0            | >= 0.66.0                | [3.12.0+]   | 21                  | 33                     | >=4.3.0 |  11.0           | Deprecated, supports Xcode 14 |
 | 10.1.0            | >= 0.66.0                | [3.11.0+]   | 21                  | 33                     | >=4.2.0 |  11.0           | Deprecated, supports Xcode 14 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="10.4.0" />
+      android:value="10.5.0" />
   </application>
 
 </manifest>

--- a/example/ios/plaidRNDemoTests/PlaidRNDemoTests.swift
+++ b/example/ios/plaidRNDemoTests/PlaidRNDemoTests.swift
@@ -6,7 +6,7 @@ final class PlaidRNDemoTests: XCTestCase {
   func testVersion() {
     let version = LinkKitVersion
 
-    XCTAssertEqual(version, "4.5.0")
+    XCTAssertEqual(version, "4.5.1")
   }
 
   func testPlaidCredentialsExist() {

--- a/example/ios/plaidRNDemoTests/PlaidRNDemoTests.swift
+++ b/example/ios/plaidRNDemoTests/PlaidRNDemoTests.swift
@@ -6,7 +6,7 @@ final class PlaidRNDemoTests: XCTestCase {
   func testVersion() {
     let version = LinkKitVersion
 
-    XCTAssertEqual(version, "4.4.0")
+    XCTAssertEqual(version, "4.5.0")
   }
 
   func testPlaidCredentialsExist() {

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"10.4.0"; // SDK_VERSION
+    return @"10.5.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 4.4.0'
+  s.dependency 'Plaid', '~> 4.5.1'
 end


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- Update iOS Native SDK.
- Add support to present Link full screen. `PlaidLinkProps` not supports passing a `LinkIOSPresentationStyle`. Pass `FULL_SCREEN` to present Link full screen instead of as a modal. For more information checkout the [pull-request](https://github.com/plaid/react-native-plaid-link-sdk/pull/543).

## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
