### PR TITLE
feat(android): add support for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,10 @@ apply plugin: 'com.android.library'
 apply plugin: "kotlin-android"
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+      namespace 'com.plaid'
+    }
     compileSdkVersion 31
 
     defaultConfig {
@@ -40,9 +44,12 @@ android {
     lintOptions {
         abortOnError false
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+
+    if (agpVersion < 8) { 
+      compileOptions {
+          sourceCompatibility JavaVersion.VERSION_1_8
+          targetCompatibility JavaVersion.VERSION_1_8
+      }
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary

Change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions). 

I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above. 

[See Kudo's comment on why we can't set JVM version on Gradle 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1677632448)

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [ ] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

## Reminder

If you made changes to typescript or javascript you'll need to update the JS bundle in the example app for tests on CI to pass. You'll need to have the SDK copied locally and then run:
`react-native bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=false --platform='ios' --assets-dest='./ios'`
