### PR TITLE
[Fix] LinkError Type Mismatch (Issue 501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,51 @@
 # RELEASES
 
-## LinkKit V10.4.0 — 2023-08-08
+## LinkKit V10.6.0 — 2023-09-XX
+
+### React Native
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |
+
+#### Changes
+
+- Resolve Issue [501](https://github.com/plaid/react-native-plaid-link-sdk/issues/501). You will now receive a LinkExit for any configuration errors.
+
+### Android
+
+[Android SDK 3.13.2](https://github.com/plaid/plaid-link-android/releases/tag/v3.13.2)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+
+
+#### Changes
+
+- Changed LinkRedirectActivity theme from Material to MaterialComponents.
+
+### iOS
+
+[iOS SDK 4.5.1](https://github.com/plaid/plaid-link-ios/releases/tag/4.5.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 14.0 |
+| iOS | >= 11.0 |
+
+#### Changes
+
+- Add identityVerificationPendingReviewSession event name.
+- Bug fixes.
+
+## LinkKit V10.5.0 — 2023-08-08
 
 ### React Native
 

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -262,8 +262,26 @@ RCT_EXPORT_METHOD(open: (BOOL)fullScreen :(RCTResponseSenderBlock)onSuccess :(RC
         };
         [self.linkHandler openWithPresentationHandler:presentationHandler dismissalHandler:dismissalHandler options:options];
     } else {
-        id error = self.creationError ? RCTJSErrorFromNSError(self.creationError) : RCTMakeError(@"create was not called", nil, nil);
-        onExit(@[error]);
+        NSString *errorMessage = self.creationError ? self.creationError.userInfo[@"message"] : @"Create was not called.";
+        NSString *errorCode = self.creationError ? [@(self.creationError.code) stringValue] : @"-1";
+
+        NSDictionary *linkExit = @{
+            @"displayMessage": errorMessage,
+            @"errorCode": errorCode,
+            @"errorType": @"creation error",
+            @"errorMessage": errorMessage,
+            @"errorDisplayMessage": errorMessage,
+            @"errorJson": [NSNull null],
+            @"metadata": @{
+                @"linkSessionId": [NSNull null],
+                @"institution": [NSNull null],
+                @"status": [NSNull null],
+                @"requestId": [NSNull null],
+                @"metadataJson": [NSNull null],
+            },
+        };
+
+        onExit(@[linkExit]);
     }
 }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Resolves [Issue 501](https://github.com/plaid/react-native-plaid-link-sdk/issues/501) where we are not sending a `LinkExit` when an invalid token is passed.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Error types should have a consistent format. 

Example LinkExit

```json
{
   "error":{
      "displayMessage":"self.clientName is , but must be a properly formatted, non-empty string",
      "errorCode":"0",
      "errorDisplayMessage":"self.clientName is , but must be a properly formatted, non-empty string",
      "errorJson":null,
      "errorMessage":"self.clientName is , but must be a properly formatted, non-empty string",
      "errorType":"creation error",
      "metadata":{
         "institution":null,
         "linkSessionId":null,
         "metadataJson":null,
         "requestId":null,
         "status":null
      }
   }
}
```

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.

1. Launch the demo app.
2. Press the open Link button (no token)
3. See properly formatted LinkExit error.


## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
