### PR TITLE
fix: add EmbeddedLinkView.web shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.6.0",
+  "version": "10.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "10.6.0",
+      "version": "10.6.2",
       "license": "MIT",
       "dependencies": {
         "react-native-plaid-link-sdk": "^10.4.0"

--- a/src/EmbeddedLink/EmbeddedLinkView.web.tsx
+++ b/src/EmbeddedLink/EmbeddedLinkView.web.tsx
@@ -1,0 +1,2 @@
+import React from 'react';
+export const EmbeddedLinkView = () => null;


### PR DESCRIPTION
fixes https://github.com/plaid/react-native-plaid-link-sdk/issues/564

## Summary
Added an `EmbeddedLinkView.web.tsx` shim file which causes web bundlers to ignore the `EmbeddedLinkView.tsx` file which imports `requireNativeComponent` (causing a compilation error with `react-native-web`)

## Motivation
We use Plaid on web and native with `react-plaid-link` and `react-native-plaid-link-sdk` and file extensions. Our implementation has been working across all platforms up until `10.6.0` and this shim will allow us to stay up to date on all platforms.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.

Tested and confirmed to work with local projects.