### PR TITLE
[Fix] Xcode < 14.3 Compile Error

### DIFF
--- a/ios/PLKEmbeddedView.swift
+++ b/ios/PLKEmbeddedView.swift
@@ -32,7 +32,7 @@ internal final class PLKEmbeddedView: UIView {
 
                 let plkLinkSuccess = success.toObjC
                 var dictionary = RNLinksdk.dictionary(from: plkLinkSuccess) ?? [:]
-                dictionary[embeddedEventName] = "onSuccess"
+                dictionary[self.embeddedEventName] = "onSuccess"
                 self.onEmbeddedEvent?(dictionary)
         })
 
@@ -41,7 +41,7 @@ internal final class PLKEmbeddedView: UIView {
 
             let plkLinkEvent = event.toObjC
             var dictionary = RNLinksdk.dictionary(from: plkLinkEvent) ?? [:]
-            dictionary[embeddedEventName] = "onEvent"
+            dictionary[self.embeddedEventName] = "onEvent"
             self.onEmbeddedEvent?(dictionary)
         }
 
@@ -50,7 +50,7 @@ internal final class PLKEmbeddedView: UIView {
 
             let plkLinkExit = exit.toObjC
             var dictionary = RNLinksdk.dictionary(from: plkLinkExit) ?? [:]
-            dictionary[embeddedEventName] = "onExit"
+            dictionary[self.embeddedEventName] = "onExit"
             self.onEmbeddedEvent?(dictionary)
         }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

If you compile for iOS with Xcode < 14.3 you'll see the following error

>Reference to property 'foo' in closure requires explicit use of 'self' to make capture semantics explicit

![Xcode Build Issue](https://github.com/plaid/react-native-plaid-link-sdk/assets/122908338/dad25b77-7e1b-430f-b4a8-31f9a58d7531)


[Allow implicit self for weak self captures, after self is unwrapped](https://github.com/apple/swift-evolution/blob/main/proposals/0365-implicit-self-weak-capture.md) covers why this doesn't impact Xcode > 14.3 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

So customers can compile with Xcode >= 14.0.1

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.


