### PR TITLE
[v10] - Update Android SDK and export more types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # RELEASES
 
+## LinkKit V10.9.0 — 2023-11-07
+
+### React Native
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |
+
+#### Changes
+
+- Update iOS SDK to [4.7.0](https://github.com/plaid/plaid-link-ios/releases/tag/4.7.0)
+
+
+### Android
+
+Android SDK [3.14.1](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+
+### Additions
+
+- Flutter usage tracking.
+
+### Changes
+
+- Change LinkActivity to SingleInstance to fix issue with OAuth Redirects on Android 14.
+
+### Removals
+
+- None
+
+
+### iOS
+
+iOS SDK [4.7.0](https://github.com/plaid/plaid-link-ios/releases/tag/4.7.0)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 14.0 |
+| iOS | >= 11.0 |
+
 ## LinkKit V10.8.0 — 2023-11-07
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can also use the `usePlaidEmitter` hook in react functional components:
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 10.9.0            | >= 0.66.0                | [3.14.1+]   | 21                  | 33                     | >=4.7.0 |  11.0           | Active, supports Xcode 14     |
 | 10.8.0            | >= 0.66.0                | [3.14.0+]   | 21                  | 33                     | >=4.7.0 |  11.0           | Active, supports Xcode 14     |
 | 10.7.0            | >= 0.66.0                | [3.14.0+]   | 21                  | 33                     | >=4.6.4 |  11.0           | Active, supports Xcode 14     |
 | 10.6.4            | >= 0.66.0                | [3.14.0+]   | 21                  | 33                     | >=4.6.4 |  11.0           | Active, supports Xcode 14     |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:3.14.0"
+    implementation "com.plaid.link:sdk-core:3.14.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="10.8.0" />
+      android:value="10.9.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"10.8.0"; // SDK_VERSION
+    return @"10.9.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.8.0",
+  "version": "10.9.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -56,7 +56,7 @@ export enum PlaidProduct {
     TRANSACTIONS="transactions",
 }
 
-enum LinkAccountType {
+export enum LinkAccountType {
     CREDIT = 'credit',
     DEPOSITORY = 'depository',
     INVESTMENT = 'investment',
@@ -64,7 +64,7 @@ enum LinkAccountType {
     OTHER = 'other',
 }
 
-enum LinkAccountSubtypes {
+export enum LinkAccountSubtypes {
     ALL = 'all',
     CREDIT_CARD = 'credit card',
     PAYPAL = 'paypal',


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- Update Android SDK to [3.14.1](https://github.com/plaid/plaid-link-android/releases/edit/v3.14.1) to resolve an Android 14 bug.
- Export `LinkAccountType` and `LinkAccountSubtypes`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Fixes Android 14 bug and allows customers to access more data types per their request.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
