### PR TITLE
[Fix] Add Clarification around no loading state - Issue 614

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ const MyPlaidComponent = () => {
             token: "#GENERATED_LINK_TOKEN#",
             // OPTIONAL - log level.
             logLevel: LinkLogLevel.ERROR,
-            // OPTIONAL - Hides native activity indicator if true.
+            // A `Bool` indicating that Link should skip displaying a loading animation until the Link UI is fully loaded.
+            // See Types.ts for more information.
             noLoadingState: false,
         }}
         onSuccess={(success: LinkSuccess) => { console.log(success) }}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -5,6 +5,12 @@ interface CommonPlaidLinkOptions {
 
 export type LinkTokenConfiguration = (CommonPlaidLinkOptions & {
     token: string;
+    // A `Bool` indicating that Link should skip displaying a loading animation until the Link UI is fully loaded.
+    // This can be used to display custom loading UI while Link content is loading (and will skip any initial loading UI in Link).
+    // Note: Dismiss custom loading UI on the OPEN & EXIT events.
+    //
+    // Note: This should be set to `true` when setting the `eu_config.headless` field in /link/token/create requests to `true`.
+    // For reference, see https://plaid.com/docs/api/tokens/#link-token-create-request-eu-config-headless
     noLoadingState: boolean;
 });
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- Adds clarifying comments about the use of `noLoadingState` in `LinkTokenConfiguration` type.
- Updates readme to state that `noLoadingState` is required.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Flagged as an [issue](https://github.com/plaid/react-native-plaid-link-sdk/issues/614)

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
