### PR TITLE
[Release] - 11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # RELEASES
 
+## LinkKit V11.3.0 — 2024-01-18
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Reverts Android SDK SDK to `4.0.0`. To prevent [issue 620](https://github.com/plaid/react-native-plaid-link-sdk/issues/620).
+
+
+### Android
+
+Android SDK [4.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.0.0)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+#### Additions
+
+- Improved Remember Me experience.
+
+### iOS
+
+iOS SDK [5.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.1.0)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
+
+#### Changes
+
+- Resolve issue where PrivacyInfo.xcprivacy was missing NSPrivacyCollectedDataTypes.
+- Improved Remember Me experience.
+- Improved OAuth out-of-process webview open options.
+
 ## LinkKit V11.2.0 — 2024-01-11
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
-| 11.2.0            | *                        | [4.1.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
+| 11.3.0            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
+| ~11.2.0~          | *                        | [4.1.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Deprecated                    |
 | 11.1.0            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.0.3            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.0.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.0.2            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.0.0 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:4.1.0"
+    implementation "com.plaid.link:sdk-core:4.0.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.2.0" />
+      android:value="11.3.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -27,7 +27,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.2.0"; // SDK_VERSION
+    return @"11.3.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.2.0",
+  "version": "11.3.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Reverts Android SDK SDK to `4.0.0`. To prevent [issue 620](https://github.com/plaid/react-native-plaid-link-sdk/issues/620).