### PR TITLE
[Release] -  10.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # RELEASES
 
+## LinkKit V10.12.0 — 2024-01-22
+
+### React Native
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |
+
+#### Changes
+
+- Updates Android SDK SDK to 3.14.3. To prevent issue [620](https://github.com/plaid/react-native-plaid-link-sdk/issues/620).
+
+### Android
+
+Android SDK [3.14.2](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.2)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+
+### iOS
+
+iOS SDK [4.7.1](https://github.com/plaid/plaid-link-ios/releases/tag/4.7.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 14.0 |
+| iOS | >= 11.0 |
+
+
 ## LinkKit V10.11.0 — 2024-01-18
 
 ### React Native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Android
 
-Android SDK [3.14.2](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.2)
+Android SDK [3.14.3](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.3)
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can also use the `usePlaidEmitter` hook in react functional components:
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 10.12.0           | >= 0.66.0                | [3.14.3+]   | 21                  | 33                     | >=4.7.1 |  11.0           | Active, supports Xcode 14     |
 | 10.11.0           | >= 0.66.0                | [3.14.2+]   | 21                  | 33                     | >=4.7.1 |  11.0           | Active, supports Xcode 14     |
 | ~10.10.0~         | >= 0.66.0                | [3.14.2+]   | 21                  | 33                     | >=4.7.1 |  11.0           | Deprecated                    |
 | 10.9.1            | >= 0.66.0                | [3.14.1+]   | 21                  | 33                     | >=4.7.0 |  11.0           | Active, supports Xcode 14     |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:3.14.1"
+    implementation "com.plaid.link:sdk-core:3.14.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="10.11.0" />
+      android:value="10.12.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"10.11.0"; // SDK_VERSION
+    return @"10.12.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.11.0",
+  "version": "10.12.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Updates Android SDK SDK to 3.14.3. To prevent issue [620](https://github.com/plaid/react-native-plaid-link-sdk/issues/620).