### PR TITLE
[Release] 11.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # RELEASES
 
+## LinkKit V11.5.0 — 2024-02-01
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Updates iOS SDK to `5.2.0` for improved Remember Me experience.
+
+
+### Android
+
+Android SDK [4.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v4.1.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+#### Additions
+
+- Improved Remember Me experience.
+
+### iOS
+
+iOS SDK [5.2.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.0)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
+
+#### Changes
+
+- Resolve issue where PrivacyInfo.xcprivacy was missing NSPrivacyCollectedDataTypes.
+- Improved Remember Me experience.
+- Improved OAuth out-of-process webview open options.
+
 ## LinkKit V11.4.0 — 2024-01-22
 
 ### React Native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,7 @@ iOS SDK [5.2.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.0)
 
 #### Changes
 
-- Resolve issue where PrivacyInfo.xcprivacy was missing NSPrivacyCollectedDataTypes.
 - Improved Remember Me experience.
-- Improved OAuth out-of-process webview open options.
 
 ## LinkKit V11.4.0 — 2024-01-22
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 11.5.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.4.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.3.0            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | ~11.2.0~          | *                        | [4.1.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | **Deprecated**                |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.4.0" />
+      android:value="11.5.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -27,7 +27,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.4.0"; // SDK_VERSION
+    return @"11.5.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m,swift}"
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 5.1.0'
+  s.dependency 'Plaid', '~> 5.2.0'
 end


### PR DESCRIPTION
## LinkKit V11.5.0 — 2024-02-01

### React Native

#### Requirements

This SDK now works with any supported version of React Native.

#### Changes

- Updates iOS SDK to `5.2.0` for improved Remember Me experience.


### Android

Android SDK [4.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v4.1.1)

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.8+ |

#### Additions

- Improved Remember Me experience.

### iOS

iOS SDK [5.2.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.0)

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 15.0.1 |
| iOS | >= 14.0 |


#### Changes

- Improved Remember Me experience.