### PR TITLE
[Release] 11.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # RELEASES
 
+## LinkKit V11.5.1 — 2024-02-08
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Resolves bug where `LinkEventMetadata` was undefined on `LinkEvent`. All values inside `LinkEventMetadata` should not be accessable on iOS and Android.
+
+
+### Android
+
+Android SDK [4.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v4.1.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+#### Additions
+
+- Improved Remember Me experience.
+
+### iOS
+
+iOS SDK [5.2.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.0)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
+
+#### Changes
+
+- Improved Remember Me experience.
+
 ## LinkKit V11.5.0 — 2024-02-01
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 11.5.1            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.5.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.4.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.3.0            | *                        | [4.0.0+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.5.0" />
+      android:value="11.5.1" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -27,7 +27,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.5.0"; // SDK_VERSION
+    return @"11.5.1"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Resolves bug where `LinkEventMetadata` was undefined on `LinkEvent`. All values inside `LinkEventMetadata` should now be accessible on iOS and Android.
- See [631](https://github.com/plaid/react-native-plaid-link-sdk/pull/631) for more information.