### PR TITLE
[Release] 11.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # RELEASES
 
+## LinkKit V11.5.2 — 2024-02-21
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Update iOS SDK
+
+### Android
+
+Android SDK [4.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v4.1.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+
+### iOS
+
+iOS SDK [5.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.1)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
+
+#### Changes
+
+- Improved Embedded Link experience.
+
 ## LinkKit V11.5.1 — 2024-02-08
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 11.5.2            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.2 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.5.1            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.5.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.4.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
-| 11.5.2            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.2 |  14.0           | Active, supports Xcode 15.0.1 |
+| 11.5.2            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.1 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.5.1            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.5.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.2.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.4.0            | *                        | [4.1.1+]    | 21                  | 33                     | >=5.1.0 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.5.1" />
+      android:value="11.5.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -27,7 +27,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.5.1"; // SDK_VERSION
+    return @"11.5.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.5.1",
+  "version": "11.5.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m,swift}"
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 5.2.0'
+  s.dependency 'Plaid', '~> 5.2.1'
 end


### PR DESCRIPTION
- Update iOS SDK to [5.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/5.2.1) to provide an improve embedded link experience.