### PR TITLE
Export create and open functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import {
     openLink,
+    create,
+    open,
     dismissLink,
     usePlaidEmitter,
     PlaidLink,
@@ -12,6 +14,8 @@ export default PlaidLink;
 export {
     PlaidLink,
     openLink,
+    create,
+    open,
     dismissLink,
     usePlaidEmitter,
 };


### PR DESCRIPTION
## Summary
Exported the `create` and `open` functions so that they don't need to be imported by deeplinking to the `dist` folder.

## Motivation
Current documentation was unclear on how to actually consume the `create` and `open` functions since the tiny example linked still uses `PlaidLink`. Further examination showed that they were not being exported from `index.ts`. The example in the repo is importing them by deeplinking the `dist` folder.

If alternatives are now deprecated these should be simpler to import.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
Import the functions.
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
