### PR TITLE
[Release] 12.0.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # RELEASES
 
+## LinkKit V12.0.0-beta.1 — 2024-05-22
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [4.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.4.0)
+
+#### Changes
+- Support Autofill for SMS OTP in Link Sessions using Google play-services-auth-api-phone library version 18.0.2.
+- Change LinkActivity to `exported=false`.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.0-beta1](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0-beta1)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.3.0 |
+| iOS | >= 14.0 |
+
+
 ## LinkKit V11.10.0 — 2024-05-22
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.0.0-beta.1     | *                        | [4.4.0+]    | 21                  | 34                     | >=6.0.0 |  14.0           | Active, supports Xcode 15.3.0 |
 | 11.10.0           | *                        | [4.4.0+]    | 21                  | 34                     | >=5.5.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.9.0            | *                        | [4.3.1+]    | 21                  | 34                     | >=5.5.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.8.2            | *                        | [4.3.1+]    | 21                  | 34                     | >=5.4.2 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.10.0" />
+      android:value="12.0.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.10.0"; // SDK_VERSION
+    return @"12.0.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.10.0",
+  "version": "12.0.0-beta.1",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 5.5.0'
+  s.dependency 'Plaid', '~> 6.0.0-beta1'
 end


### PR DESCRIPTION
## LinkKit V12.0.0-beta.1 — 2024-05-22

### React Native

#### Requirements

This SDK now works with any supported version of React Native.

### Android

Android SDK [4.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.4.0)

#### Changes
- Support Autofill for SMS OTP in Link Sessions using Google play-services-auth-api-phone library version 18.0.2.
- Change LinkActivity to `exported=false`.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.8+ |

### iOS

iOS SDK [6.0.0-beta1](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0-beta1)

#### Changes

- Add support for FinanceKit and Apple card.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 15.3.0 |
| iOS | >= 14.0 |