### PR TITLE
[Release] - 10.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # RELEASES
 
+## LinkKit V10.13.2 — 2024-05-30
+
+### React Native
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |
+
+#### Changes
+
+- Update iOS SDK
+
+### Android
+
+Android SDK [3.14.3](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.3)
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+
+### iOS
+
+iOS SDK [4.7.8](https://github.com/plaid/plaid-link-ios/releases/tag/4.7.8)
+
+#### Changes
+
+- Fix headless OAuth bug.
+- Improved Remember Me experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 14.0 |
+| iOS | >= 11.0 |
+
 ## LinkKit V10.13.1 — 2024-02-08
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can also use the `usePlaidEmitter` hook in react functional components:
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 10.13.2           | >= 0.66.0                | [3.14.3+]   | 21                  | 33                     | >=4.7.8 |  11.0           | Active, supports Xcode 14     |
 | 10.13.1           | >= 0.66.0                | [3.14.3+]   | 21                  | 33                     | >=4.7.2 |  11.0           | Active, supports Xcode 14     |
 | 10.13.0           | >= 0.66.0                | [3.14.3+]   | 21                  | 33                     | >=4.7.2 |  11.0           | Active, supports Xcode 14     |
 | 10.12.0           | >= 0.66.0                | [3.14.3+]   | 21                  | 33                     | >=4.7.1 |  11.0           | Active, supports Xcode 14     |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="10.13.1" />
+      android:value="10.13.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.m
+++ b/ios/RNLinksdk.m
@@ -117,7 +117,7 @@ NSString* const kRNLinkKitPublicTokenPrefix = @"public-";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"10.13.1"; // SDK_VERSION
+    return @"10.13.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "10.13.1",
+  "version": "10.13.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m,swift}"
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 4.7.2'
+  s.dependency 'Plaid', '~> 4.7.8'
 end


### PR DESCRIPTION
## LinkKit V10.13.2 — 2024-05-30

### React Native

#### Requirements

| Name | Version |
|------|---------|
| React Native | >= [66.0](https://reactnative.dev/blog/2021/10/01/version-066) |

#### Changes

- Update iOS SDK

### Android

Android SDK [3.14.3](https://github.com/plaid/plaid-link-android/releases/tag/v3.14.3)

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |

### iOS

iOS SDK [4.7.8](https://github.com/plaid/plaid-link-ios/releases/tag/4.7.8)

#### Changes

- Fix headless OAuth bug.
- Improved Remember Me experience.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 14.0 |
| iOS | >= 11.0 |