### PR TITLE
fix: change minSdkVersion for RN 0.74.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion rootProject.ext.safeExtGet("minSdkVersion", 21)
         targetSdkVersion 31
         versionCode 1
         versionName "0.0.1"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Update minSdkVersion to 23 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
React Native 0.74.1 added [the minimum SDK version bump to 23](https://reactnative.dev/blog/2024/04/22/release-0.74#android-minimum-sdk-bump-android-60). This PR tends to add the same, making sure the previous 21 is intact.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
