### PR TITLE
[Release] 11.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # RELEASES
 
+## LinkKit V11.12.0 — 2024-08-09
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Resolve issue [693](https://github.com/plaid/react-native-plaid-link-sdk/issues/693) missing Layer events.
+- Add `LAYER_READY` and `LAYER_NOT_AVAILABLE` events to `LinkEventName`.
+
+### Android
+
+Android SDK [4.6.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.6.0)
+
+#### Changes
+- Source and target compatibility set to JavaVersion.VERSION_11 down from VERSION_17 to improve compatibility.
+- Upgrade androidx.work:work-runtime-ktx library from 2.7.1 to 2.9.0.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [5.6.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.6.0)
+
+#### Changes
+
+- Add submit API for Layer.
+- Improved Remember Me Experience
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
 ## LinkKit V11.11.2 — 2024-08-06
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 11.12.0           | *                        | [4.6.0+]    | 21                  | 34                     | >=5.6.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.11.2           | *                        | [4.5.1+]    | 21                  | 34                     | >=5.6.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.11.1           | *                        | [4.5.1+]    | 21                  | 34                     | >=5.6.0 |  14.0           | Active, supports Xcode 15.0.1 |
 | 11.11.0           | *                        | [4.5.0+]    | 21                  | 34                     | >=5.6.0 |  14.0           | Active, supports Xcode 15.0.1 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,7 +106,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:4.5.1"
+    implementation "com.plaid.link:sdk-core:4.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.11.2" />
+      android:value="11.12.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.11.2"; // SDK_VERSION
+    return @"11.12.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.11.2",
+  "version": "11.12.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## LinkKit V11.12.0 — 2024-08-09

### React Native

#### Requirements

This SDK now works with any supported version of React Native.

#### Changes

- Resolve issue [693](https://github.com/plaid/react-native-plaid-link-sdk/issues/693) missing Layer events.
- Add `LAYER_READY` and `LAYER_NOT_AVAILABLE` events to `LinkEventName`.

### Android

Android SDK [4.6.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.6.0)

#### Changes
- Source and target compatibility set to JavaVersion.VERSION_11 down from VERSION_17 to improve compatibility.
- Upgrade androidx.work:work-runtime-ktx library from 2.7.1 to 2.9.0.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.8+ |

### iOS

iOS SDK [5.6.0](https://github.com/plaid/plaid-link-ios/releases/tag/5.6.0)

#### Changes

- Add submit API for Layer.
- Improved Remember Me Experience

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 15.0.1 |
| iOS | >= 14.0 |