### PR TITLE
feat: add use_frameworks support

### DIFF
--- a/ios/PLKFabricHelpers.h
+++ b/ios/PLKFabricHelpers.h
@@ -5,7 +5,11 @@
 #if __has_include(<rnplaidlink/react_native_plaid_link_sdk-Swift.h>)
 #import <rnplaidlink/react_native_plaid_link_sdk-Swift.h>
 #else
+#ifdef USE_FRAMEWORKS
+#import <react_native_plaid_link_sdk/react_native_plaid_link_sdk-Swift.h>
+#else
 #import <react_native_plaid_link_sdk-Swift.h>
+#endif
 #endif
 
 // copied from RCTFollyConvert

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -21,6 +21,13 @@ Pod::Spec.new do |s|
   # we don't want this to be seen by Swift
   s.private_header_files = 'ios/PLKFabricHelpers.h'
 
+  if ENV['USE_FRAMEWORKS'] == '1'
+    s.pod_target_xcconfig = {
+      "OTHER_CFLAGS" => "$(inherited) -DUSE_FRAMEWORKS",
+      "OTHER_CPLUSPLUSFLAGS" => "$(inherited) -DUSE_FRAMEWORKS",
+    }
+  end
+
   if fabric_enabled
     install_modules_dependencies(s)
   else


### PR DESCRIPTION
## PR concerning New Architecture support in the library :tada:

We at [Software Mansion](https://swmansion.com/) have been working on [improving support](https://blog.swmansion.com/sunrising-new-architecture-in-the-new-expensify-app-729d237a02f5) for the new architecture for quite a while now. If you need help with anything related to New Architecture, like:
- [migrating your library](https://x.com/swmansion/status/1717512089323864275)
- [migrating your app](https://github.com/Expensify/App/pull/13767)
- [investigating issues](https://github.com/facebook/react-native/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aj-piasecki+is%3Aopen)
- [improving performance](https://x.com/BBloniarz_/status/1808138585528303977)

or you just want to ask any questions, hit us up on [projects@swmansion.com](mailto:projects@swmansion.com)

---


### Summary
<!-- Simple summary of what was changed. -->

Add support for `use_frameworks` flag, similar to how it is done in `mapbox`: https://github.com/rnmapbox/maps/blob/e5b1ca5326f08009010d108d0b30e7269efd0859/rnmapbox-maps.podspec#L266-L268 and https://github.com/rnmapbox/maps/blob/e5b1ca5326f08009010d108d0b30e7269efd0859/ios/RNMBX/rnmapbox_maps-Swift.pre.h#L10-L14
