### PR TITLE
[Fix] Update Android Compile Version to 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # RELEASES
 
+## LinkKit V11.13.2 — 2024-11-12
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+#### Changes
+
+- Update Android Compile Version to 34.
+
+### Android
+
+Android SDK [4.6.1](https://github.com/plaid/plaid-link-android/releases/tag/v4.6.1)
+
+#### Changes
+- Add BANK_INCOME_INSIGHTS_COMPLETED, SUBMIT_EMAIL, SKIP_SUBMIT_EMAIL, SUBMIT_OTP, REMEMBER_ME_ENABLED, REMEMBER_ME_DISABLED, REMEMBER_ME_DISABLED, REMEMBER_ME_HOLDOUT, PLAID_CHECK_PANE, AUTO_SELECT_SAVED_INSTITUTION event names.
+- Add SUBMIT_DOCUMENTS, SUBMIT_DOCUMENTS_SUCCESS, SUBMIT_DOCUMENTS_ERROR, SUBMIT_EMAIL, and VERIFY_EMAIL event view names.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [5.6.1](https://github.com/plaid/plaid-link-ios/releases/tag/5.6.1)
+
+#### Changes
+
+- Add missing event names submitEmail, skipSubmitEmail, rememberMeEnabled, rememberMeDisabled, rememberMeHoldout, selectSavedInstitution, selectSavedAccount, autoSelectSavedInstitution, plaidCheckPane.
+- Add missing view names submitEmail and verifyEmail.
+- Add haptics support.
+- Fix Embedded search view dynamic resizing.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.0.1 |
+| iOS | >= 14.0 |
+
 ## LinkKit V11.13.1 — 2024-11-11
 
 ### React Native

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
     }
@@ -60,11 +60,11 @@ android {
     if (agpVersion >= 7) {
       namespace 'com.plaid'
     }
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion rootProject.ext.has("minSdkVersion") ? rootProject.ext.minSdkVersion :  21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 1
         versionName "0.0.1"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
@@ -75,8 +75,8 @@ android {
 
     if (agpVersion < 8) { 
       compileOptions {
-          sourceCompatibility JavaVersion.VERSION_1_8
-          targetCompatibility JavaVersion.VERSION_1_8
+          sourceCompatibility JavaVersion.VERSION_17
+          targetCompatibility JavaVersion.VERSION_17
       }
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,8 +75,8 @@ android {
 
     if (agpVersion < 8) { 
       compileOptions {
-          sourceCompatibility JavaVersion.VERSION_17
-          targetCompatibility JavaVersion.VERSION_17
+          sourceCompatibility JavaVersion.VERSION_1_8
+          targetCompatibility JavaVersion.VERSION_1_8
       }
     }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 09 09:41:09 PST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="11.13.1" />
+      android:value="11.13.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"11.13.1"; // SDK_VERSION
+    return @"11.13.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.13.0",
+  "version": "11.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "11.13.0",
+      "version": "11.13.1",
       "license": "MIT",
       "devDependencies": {
         "@react-native-community/eslint-plugin": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "11.13.1",
+  "version": "11.13.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updates the android compile version to 34.

How to test:

At the root of the project run: 
- start android emulator ex `emulator -avd Pixel_7_API_34`
- npm install
- `tsc && yalc publish && cd example && yalc add react-native-plaid-link-sdk && npm install && npm run android && cd ../`