### PR TITLE
[Release] 12.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # RELEASES
 
+## LinkKit V12.0.2 — 2025-01-30
+
+### React Native
+
+- Fixed: Resolved an [issue](https://github.com/plaid/react-native-plaid-link-sdk/issues/747) where the USE_FRAMEWORKS preprocessor check was failing for projects using use_frameworks! :linkage => :static.
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.2)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+- Improved returning user experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.0.1 — 2025-01-24
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.0.2            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.2 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.1            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.2 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.0            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.0-beta.3     | *                        | [4.4.0+]    | 21                  | 34                     | >=6.0.0 |  14.0           | Active, supports Xcode 15.3.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.0.1" />
+      android:value="12.0.2" />
   </application>
 
 </manifest>

--- a/ios/PLKFabricHelpers.h
+++ b/ios/PLKFabricHelpers.h
@@ -19,8 +19,9 @@
 #import <react_native_plaid_link_sdk/react_native_plaid_link_sdk-Swift.h>
 
 #else
-#ifdef USE_FRAMEWORKS
+#if __has_include(<react_native_plaid_link_sdk/react_native_plaid_link_sdk-Swift.h>)
 // Include the header for projects using frameworks (`use_frameworks!` in the Podfile).
+// Frameworks are being used (static or dynamic).
 #import <react_native_plaid_link_sdk/react_native_plaid_link_sdk-Swift.h>
 
 #else
@@ -45,6 +46,7 @@
  3. Refer to these GitHub issues for more details:
     - https://github.com/plaid/react-native-plaid-link-sdk/issues/713
     - https://github.com/plaid/react-native-plaid-link-sdk/issues/732
+    - https://github.com/plaid/react-native-plaid-link-sdk/issues/747
 
  ### Troubleshooting:
  - If `USE_FRAMEWORKS` is not working, ensure it is correctly passed as a preprocessor macro in your Xcode build settings.

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.0.1"; // SDK_VERSION
+    return @"12.0.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixed: Resolved an issue #747 where the USE_FRAMEWORKS preprocessor check was failing for projects using use_frameworks! :linkage => :static.

Update: Replaced the USE_FRAMEWORKS check with __has_include to properly detect whether the framework is available, ensuring compatibility with both static and dynamic linking configurations.

Impact: This fix allows projects using static frameworks to correctly import react_native_plaid_link_sdk without compilation errors.