### PR TITLE
[Release] - 12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # RELEASES
 
+## LinkKit V12.1.0 — 2025-03-10
+
+### React Native
+
+- Updates iOS SDK to [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
+- Resolves [issue 754](https://github.com/plaid/react-native-plaid-link-sdk/issues/754)
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
+
+#### Changes
+
+- Improved RememberMe experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.0.3 — 2025-02-04
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.1.0            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.1.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.3            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.4 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.2            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.2 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.1            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.2 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.0.3" />
+      android:value="12.1.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.0.3"; // SDK_VERSION
+    return @"12.1.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.0.3",
+  "version": "12.1.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -35,5 +35,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.0.4'
+  s.dependency 'Plaid', '~> 6.1.0'
 end


### PR DESCRIPTION
## LinkKit V12.1.0 — 2025-03-10

### React Native

- Updates iOS SDK to [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
- Resolves [issue 754](https://github.com/plaid/react-native-plaid-link-sdk/issues/754)

#### Requirements

This SDK now works with any supported version of React Native.

### Android

Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)

### Additions

- Add AUTO_SUBMIT event name.
- Add INVALID_UPDATE_USERNAME item error.

### Changes

- Upgrade Kotlin to 1.9.25.
- Upgrade to target and compile SDK version 35.
- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.

### Removals

- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.8+ |

### iOS

iOS SDK [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)

#### Changes

- Improved RememberMe experience.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |