### PR TITLE
Remove async def from open

### DIFF
--- a/src/PlaidLink.tsx
+++ b/src/PlaidLink.tsx
@@ -51,7 +51,7 @@ export const create = (props: LinkTokenConfiguration) => {
   }
 };
 
-export const open = async (props: LinkOpenProps) => {
+export const open = (props: LinkOpenProps) => {
   if (Platform.OS === 'android') {
     RNLinksdkAndroid?.open(
       (result: LinkSuccess) => {


### PR DESCRIPTION
## Summary
Remove async def from open

## Motivation
Function definition is inaccurate and misleading since its callback-based and not promise-based

## :pencil: Checklist
- [yes] I have performed a self-review of my own code.
- [yes] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [tested locally in my app] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
