### PR TITLE
Remove unused dependency from Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -108,5 +108,4 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
     implementation "com.plaid.link:sdk-core:5.0.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- the `com.jakewharton.rxrelay2:rxrelay:2.1.1` dependency is not needed. This PR removes it.

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes by building and testing the example app.
