### PR TITLE
[Release] - 12.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # RELEASES
 
+## LinkKit V12.2.0 — 2025-06-13
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Add Flutter SDK version tracking.
+- Fixed edge to edge layout overlap issue in Android 15+.
+
+### Removals
+
+- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
+- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)
+
+#### Changes
+
+- Add Flutter SDK version tracking.
+- Reduced SDK size from 13.2MB to 8.9MB
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.1.1 — 2025-04-03
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.2.0            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.1.1            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.1.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.1.0            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.1.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.0.3            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.0.4 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.0.0"
+    implementation "com.plaid.link:sdk-core:5.1.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.1.1" />
+      android:value="12.2.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.1.1"; // SDK_VERSION
+    return @"12.2.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.1.1",
+  "version": "12.2.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -35,5 +35,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.1.0'
+  s.dependency 'Plaid', '~> 6.2.1'
 end


### PR DESCRIPTION
## LinkKit V12.2.0 — 2025-06-13

#### Requirements

This SDK now works with any supported version of React Native.

### Android

Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)

### Additions

- Add AUTO_SUBMIT event name.
- Add INVALID_UPDATE_USERNAME item error.

### Changes

- Add Flutter SDK version tracking.
- Fixed edge to edge layout overlap issue in Android 15+.

### Removals

- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)

#### Changes

- Add Flutter SDK version tracking.
- Reduced SDK size from 13.2MB to 8.9MB

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |