### PR TITLE
Update RNLinksdk.mm - remove PLKEnvironmentDevelopment

### DIFF
--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -223,13 +223,9 @@ RCT_EXPORT_METHOD(submit:(NSString * _Nullable)phoneNumber) {
         return PLKEnvironmentSandbox;
     }
 
-    if ([string isEqualToString:@"development"]) {
-        return PLKEnvironmentDevelopment;
-    }
-
-    // Default to Development
-    NSLog(@"Unexpected environment string value: %@. Expected one of: production, sandbox, or development.", string);
-    return PLKEnvironmentDevelopment;
+    // Default to Sandbox
+    NSLog(@"Unexpected environment string value: %@. Expected one of: production, sandbox.", string);
+    return PLKEnvironmentSandbox;
 }
 
 + (NSDictionary *)dictionaryFromSuccess:(PLKLinkSuccess *)success {


### PR DESCRIPTION
## Summary
Remove PLKEnvironmentDevelopment, which no longer exists in Plaid SDK.

## Motivation
https://github.com/plaid/react-native-plaid-link-sdk/issues/782

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [x] I have manually tested my changes.


## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
