### PR TITLE
[Release] - 12.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # RELEASES
 
+## LinkKit V12.2.1 — 2025-06-21
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [782 PLKEnvironmentDevelopment not defined](https://github.com/plaid/react-native-plaid-link-sdk/issues/782).
+
+### Android
+
+Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Add Flutter SDK version tracking.
+- Fixed edge to edge layout overlap issue in Android 15+.
+
+### Removals
+
+- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
+- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)
+
+#### Changes
+
+- Add Flutter SDK version tracking.
+- Reduced SDK size from 13.2MB to 8.9MB
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.2.0 — 2025-06-13
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.2.1            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.2.0            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.1.1            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.1.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.1.0            | *                        | [5.0.0+]    | 21                  | 34                     | >=6.1.0 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.2.0" />
+      android:value="12.2.1" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.2.0"; // SDK_VERSION
+    return @"12.2.1"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## LinkKit V12.2.1 — 2025-06-21

#### Requirements

This SDK now works with any supported version of React Native.

### Changes

- Resolve issue [782 PLKEnvironmentDevelopment not defined](https://github.com/plaid/react-native-plaid-link-sdk/issues/782).

### Android

Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)

### Additions

- Add AUTO_SUBMIT event name.
- Add INVALID_UPDATE_USERNAME item error.

### Changes

- Add Flutter SDK version tracking.
- Fixed edge to edge layout overlap issue in Android 15+.

### Removals

- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)

#### Changes

- Add Flutter SDK version tracking.
- Reduced SDK size from 13.2MB to 8.9MB

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |