### PR TITLE
[Release] - 12.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # RELEASES
 
+## LinkKit V12.3.1 — 2025-07-28
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)
+
+### Additions
+
+- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.
+
+### Changes
+
+- Improve destroy() API behavior in edge cases.
+
+### Removals
+
+- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
+- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.3.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.1)
+
+### Changes
+
+- Expose Finance Kit sync simulated behavior to Objective-C (React Native).
+- Updated Layer submit API
+- Added Layer event LAYER_AUTOFILL_NOT_AVAILABLE
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
 ## LinkKit V12.3.0 — 2025-07-24
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.3.1            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.3.0            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.2.1            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.2.0            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.3.0" />
+      android:value="12.3.1" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -183,11 +183,13 @@ RCT_EXPORT_METHOD(dismiss) {
 
 RCT_EXPORT_METHOD(syncFinanceKit:(NSString *)token
                   requestAuthorizationIfNeeded:(BOOL)requestAuthorizationIfNeeded
+                  simulatedBehavior:(BOOL)simulatedBehavior
                   onSuccess:(RCTResponseSenderBlock)onSuccess
                   onError:(RCTResponseSenderBlock)onError) {
 
     [RNPlaidHelper syncFinanceKit:token
          requestAuthorizationIfNeeded:requestAuthorizationIfNeeded
+         simulatedBehavior: simulatedBehavior
          onSuccess:^{
             onSuccess(@[]);
         }
@@ -202,7 +204,6 @@ RCT_EXPORT_METHOD(syncFinanceKit:(NSString *)token
         }
     ];
 }
-                  
 
 RCT_EXPORT_METHOD(submit:(NSString * _Nullable)phoneNumber) {
     if (self.linkHandler) {

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.3.0"; // SDK_VERSION
+    return @"12.3.1"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/ios/RNPlaidHelper.h
+++ b/ios/RNPlaidHelper.h
@@ -2,10 +2,13 @@
 
 @interface RNPlaidHelper : NSObject
 
-+ (id <PLKHandler> _Nullable)createWithLinkTokenConfiguration:(PLKLinkTokenConfiguration * _Nonnull)linkTokenConfiguration error:(NSError * _Nullable * _Nullable)error;
++ (id<PLKHandler> _Nullable)createWithLinkTokenConfiguration:(PLKLinkTokenConfiguration * _Nonnull)linkTokenConfiguration
+                                                       error:(NSError * _Nullable * _Nullable)error;
 
-+ (void) syncFinanceKit:(NSString *_Nonnull)token
-        requestAuthorizationIfNeeded:(BOOL)requestAuthorizationIfNeeded
++ (void)syncFinanceKit:(NSString * _Nonnull)token
+requestAuthorizationIfNeeded:(BOOL)requestAuthorizationIfNeeded
+     simulatedBehavior:(BOOL)simulatedBehavior
               onSuccess:(void (^_Nonnull)(void))onSuccess
                 onError:(void (^_Nonnull)(NSError * _Nonnull error))onError;
+
 @end

--- a/ios/RNPlaidHelper.m
+++ b/ios/RNPlaidHelper.m
@@ -2,18 +2,28 @@
 
 @implementation RNPlaidHelper
 
-+ (id <PLKHandler> _Nullable)createWithLinkTokenConfiguration:(PLKLinkTokenConfiguration * _Nonnull)linkTokenConfiguration error:(NSError * _Nullable * _Nullable)error
++ (id<PLKHandler> _Nullable)createWithLinkTokenConfiguration:(PLKLinkTokenConfiguration * _Nonnull)linkTokenConfiguration
+                                                       error:(NSError * _Nullable * _Nullable)error
 {
     return [PLKPlaid createWithLinkTokenConfiguration:linkTokenConfiguration error:error];
 }
 
-+ (void)syncFinanceKit:(NSString *)token requestAuthorizationIfNeeded:(BOOL)requestAuthorizationIfNeeded onSuccess:(void (^)(void))onSuccess onError:(void (^)(NSError * _Nonnull))onError {
++ (void)syncFinanceKit:(NSString * _Nonnull)token
+requestAuthorizationIfNeeded:(BOOL)requestAuthorizationIfNeeded
+     simulatedBehavior:(BOOL)simulatedBehavior
+              onSuccess:(void (^_Nonnull)(void))onSuccess
+                onError:(void (^_Nonnull)(NSError * _Nonnull error))onError
+{
     if (@available(iOS 17.4, *)) {
-        [PLKPlaid syncFinanceKitWithToken:token requestAuthorizationIfNeeded:requestAuthorizationIfNeeded onSuccess:onSuccess onError:onError];
+        [PLKPlaid syncFinanceKitWithToken:token
+           requestAuthorizationIfNeeded:requestAuthorizationIfNeeded
+                      simulatedBehavior:simulatedBehavior
+                               onSuccess:onSuccess
+                                 onError:onError];
     } else {
         NSError *error = [NSError errorWithDomain:@"com.plaid.financeKit"
-                                  code:1001
-                                  userInfo:@{ NSLocalizedDescriptionKey: @"FinanceKit Requires iOS >= 17.4" }];
+                                             code:1001
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"FinanceKit Requires iOS >= 17.4" }];
         onError(error);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -35,5 +35,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.3.0'
+  s.dependency 'Plaid', '~> 6.3.1'
 end

--- a/src/PlaidLink.tsx
+++ b/src/PlaidLink.tsx
@@ -138,6 +138,7 @@ export const submit = (data: SubmissionData): void => {
 export const syncFinanceKit = (
   token: string,
   requestAuthorizationIfNeeded: boolean,
+  simulatedBehavior: boolean,
   completion: (error?: FinanceKitError) => void
 ): void => {
     if (Platform.OS === 'android') {
@@ -148,7 +149,8 @@ export const syncFinanceKit = (
     } else {
       RNLinksdkiOS?.syncFinanceKit(
         token, 
-        requestAuthorizationIfNeeded, 
+        requestAuthorizationIfNeeded,
+        simulatedBehavior,
         () => {
           completion()
         },

--- a/src/fabric/NativePlaidLinkModuleiOS.ts
+++ b/src/fabric/NativePlaidLinkModuleiOS.ts
@@ -20,6 +20,7 @@ export interface Spec extends TurboModule {
     syncFinanceKit(
       token: string,
       requestAuthorizationIfNeeded: boolean,
+      simulatedBehavior: boolean,
       onSuccess: (success: boolean) => void,
       onError: (error: UnsafeObject<FinanceKitError>) => void
     ): void


### PR DESCRIPTION
## LinkKit V12.3.1 — 2025-07-28

#### Requirements

This SDK now works with any supported version of React Native.

### Android

Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)

### Additions

- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.

### Changes

- Improve destroy() API behavior in edge cases.

### Removals

- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.3.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.1)

### Changes

- Expose Finance Kit sync simulated behavior to Objective-C (React Native).
- Updated Layer submit API
- Added Layer event LAYER_AUTOFILL_NOT_AVAILABLE

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |