### PR TITLE
fix: add ios.componentProvider to codegenConfig to resolve deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "javaPackageName": "com.plaid"
     },
     "ios": {
-      "componentProvider": "RNPlaidLinkComponentProvider"
+      "componentProvider": "PLKEmbeddedViewCls"
     }
   }
 }


### PR DESCRIPTION
## Summary
React Native's codegen system now requires the 'ios.componentProvider' property in codegenConfig for libraries using Fabric components. This change addresses the deprecation warning:

'[Codegen] [DEPRECATED] react-native-plaid-link-sdk should add the ios.componentProvider property in their codegenConfig'

Changes:

Added ios.componentProvider: `PLKEmbeddedViewCls` to package.json
Follows React Native 0.74+ codegen requirements for new architecture
Ensures compatibility with future React Native versions

References:
React Native New Architecture: https://reactnative.dev/docs/the-new-architecture/landing-page
Codegen Configuration: https://reactnative.dev/docs/the-new-architecture/pillars-codegen
Fabric Components: https://reactnative.dev/docs/the-new-architecture/pillars-fabric-components
Impact:

Resolves build warnings in development
Ensures forward compatibility with React Native updates
Maintains support for Fabric-enabled PLKEmbeddedView component

## Motivation
Getting deprecation notices in my application's logs.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [ ] I have manually tested my changes.


## Documentation

Select one:
 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
