### PR TITLE
[Release] - 12.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # RELEASES
 
+## LinkKit V12.3.2 — 2025-07-30
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)
+
+### Additions
+
+- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.
+
+### Changes
+
+- Improve destroy() API behavior in edge cases.
+
+### Removals
+
+- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
+- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.3.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.2)
+
+### Changes
+
+- Resolve XCFramework signing issue.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.3.1 — 2025-07-28
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ While these older versions are expected to continue to work without disruption, 
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
-| 12.3.1            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.1 |  14.0           | Active, supports Xcode 16.1.0 |
+| 12.3.2            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.2 |  14.0           | Active, supports Xcode 16.1.0 |
+| 12.3.1            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.1 |  14.0           | **Deprecated** |
 | 12.3.0            | *                        | [5.2.0+]    | 21                  | 34                     | >=6.3.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.2.1            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.2.0            | *                        | [5.1.1+]    | 21                  | 34                     | >=6.2.1 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.3.1" />
+      android:value="12.3.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.3.1"; // SDK_VERSION
+    return @"12.3.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.3.1",
+  "version": "12.3.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -35,5 +35,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.3.1'
+  s.dependency 'Plaid', '~> 6.3.2'
 end


### PR DESCRIPTION
## LinkKit V12.3.2 — 2025-07-30

#### Requirements

This SDK now works with any supported version of React Native.

### Android

Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)

### Additions

- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.

### Changes

- Improve destroy() API behavior in edge cases.

### Removals

- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.3.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.2)

### Changes

- Resolve XCFramework signing issue.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |
