### PR TITLE
[Release] - 12.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # RELEASES
 
+## LinkKit V12.5.0 — 2025-09-04
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Updates Android SDK to the latest version.
+- Resolve issue [804](https://github.com/plaid/react-native-plaid-link-sdk/issues/804) bottom Navigation Bar Overlapping UI Elements
+
+
+### Android
+
+Android SDK [5.3.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.2)
+
+### Additions
+
+- Upgrade com.google.protobuf:protobuf-kotlin-lite to 3.25.5
+- Ensure SDK screens resize for keyboard insets on Android 15+
+
+### Changes
+
+- None
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.4.0 — 2025-08-06
 
 #### Requirements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.3.0"
+    implementation "com.plaid.link:sdk-core:5.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.4.0" />
+      android:value="12.5.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.4.0"; // SDK_VERSION
+    return @"12.5.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.4.0",
+  "version": "12.5.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# RELEASES

## LinkKit V12.5.0 — 2025-09-04

#### Requirements

This SDK now works with any supported version of React Native.

### Changes

- Updates Android SDK to the latest version.
- Resolve issue [804](https://github.com/plaid/react-native-plaid-link-sdk/issues/804) bottom Navigation Bar Overlapping UI Elements


### Android

Android SDK [5.3.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.2)

### Additions

- Upgrade com.google.protobuf:protobuf-kotlin-lite to 3.25.5
- Ensure SDK screens resize for keyboard insets on Android 15+

### Changes

- None

### Removals

- None

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)

### Changes

- Add issueDescription and issueDetectedAt to EventMetadata.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |
