### PR TITLE
[Fix] - Metadata json key

### DIFF
--- a/android/src/main/java/com/plaid/gson/RNEventMetadataAdapter.kt
+++ b/android/src/main/java/com/plaid/gson/RNEventMetadataAdapter.kt
@@ -39,7 +39,8 @@ class RNEventMetadataAdapter : JsonSerializer<LinkEventMetadata> {
       addProperty("issueId", src.issueId)
       addProperty("timestamp", src.timestamp)
       addProperty("viewName", src.viewName?.jsonValue ?: "")
-      addProperty("metadata_json", src.metadataJson)
+      addProperty("metadata_json", src.metadataJson) // deprecated
+      addProperty("metadataJson", src.metadataJson)
     }
     return obj
   }

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -355,7 +355,8 @@ RCT_EXPORT_METHOD(submit:(NSString * _Nullable)phoneNumber dateOfBirth:(NSString
             @"issueId": metadata.issueID ?: @"",
             @"timestamp": [self iso8601StringFromDate:metadata.timestamp] ?: @"",
             @"viewName": [self stringForViewName:metadata.viewName] ?: @"",
-            @"metadata_json": metadata.metadataJSON ?: @"",
+            @"metadata_json": metadata.metadataJSON ?: @"", // deprecated
+            @"metadataJson": metadata.metadataJSON ?: @"",
         },
     };
 }


### PR DESCRIPTION
Updates event to encode `metadataJson` in addition to `metadata_json`. We will remove `metadata_json` in the next major release. This makes all casing consistent (camelCase).