### PR TITLE
[Release] 12.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # RELEASES
 
+## LinkKit V12.5.3 — 2025-09-16
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [816](https://github.com/plaid/react-native-plaid-link-sdk/issues/816) with Android SDK upgrade to v5.3.4.
+
+### Android
+
+Android SDK [5.3.4](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.4)
+
+### Additions
+
+- None
+
+### Changes
+
+- Fix retrofit reinitialization bug in edge cases.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
 ## LinkKit V12.5.2 — 2025-09-10
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.5.3            | *                        | [5.3.4+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.2            | *                        | [5.3.3+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.1            | *                        | [5.3.2+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.0            | *                        | [5.3.2+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.3.3"
+    implementation "com.plaid.link:sdk-core:5.3.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.5.2" />
+      android:value="12.5.3" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.5.2"; // SDK_VERSION
+    return @"12.5.3"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.5.2",
+  "version": "12.5.3",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## LinkKit V12.5.3 — 2025-09-16

#### Requirements

This SDK now works with any supported version of React Native.

### Changes

- Resolve issue [816](https://github.com/plaid/react-native-plaid-link-sdk/issues/816) with Android SDK upgrade to v5.3.4.

### Android

Android SDK [5.3.4](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.4)

### Additions

- None

### Changes

- Fix retrofit reinitialization bug in edge cases.

### Removals

- None

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)

### Changes

- Add issueDescription and issueDetectedAt to EventMetadata.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |

