### PR TITLE
Use reactApplicationContext for currentActivity

### DIFF
--- a/android/src/main/java/com/plaid/PlaidModule.kt
+++ b/android/src/main/java/com/plaid/PlaidModule.kt
@@ -126,7 +126,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   override fun open(onSuccessCallback: Callback, onExitCallback: Callback) {
-    val activity = currentActivity ?: throw IllegalStateException("Current activity is null")
+    val activity = reactApplicationContext.currentActivity ?: throw IllegalStateException("Current activity is null")
 
     plaidHandler?.let { handler ->
       // Work with nonNullValue here
@@ -176,7 +176,7 @@ class PlaidModule internal constructor(reactContext: ReactApplicationContext) :
     onSuccessCallback: Callback,
     onExitCallback: Callback
   ) {
-    val activity = currentActivity ?: throw IllegalStateException("Current activity is null")
+    val activity = reactApplicationContext.currentActivity ?: throw IllegalStateException("Current activity is null")
     this.onSuccessCallback = onSuccessCallback
     this.onExitCallback = onExitCallback
 


### PR DESCRIPTION

## Summary
Fixed `Unresolved reference 'currentActivity'` error when compiling on Android with React Native 0.81.4.

Other libraries also had to fix this, for example rn-datepicker:
https://github.com/react-native-datetimepicker/datetimepicker/pull/1003/files

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

When building in newer React Native versions on Android, you will see the error `Unresolved reference 'currentActivity'`. This is because `currentActivity` was removed.

## :pencil: Checklist
- [x] I have performed a self-review of my own code.
- [x] I have optimized code readability (class/variable names, straight forward logic paths, short clarifying docs,...).

## :green_heart: Testing
<!--- Explain how to test your changes -->
- [ ] I have manually tested my changes.


## Documentation

Select one:
 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
