### PR TITLE
12.6.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # RELEASES
 
+## LinkKit V12.6.0 — 2025-10-06
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively. 
+- Upgrade to Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+- Upgrade to iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)
+
+### Android
+
+Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+
+### Additions
+
+- None
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
 ## LinkKit V12.5.3 — 2025-09-16
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.6.0            | *                        | [5.4.0+]    | 21                  | 34                     | >=6.4.1 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.3            | *                        | [5.3.4+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.2            | *                        | [5.3.3+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.5.1            | *                        | [5.3.2+]    | 21                  | 34                     | >=6.4.0 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.3.4"
+    implementation "com.plaid.link:sdk-core:5.4.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.5.3" />
+      android:value="12.6.0" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.5.3"; // SDK_VERSION
+    return @"12.6.0"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.5.3",
+  "version": "12.6.0",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -36,5 +36,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.4.0'
+  s.dependency 'Plaid', '~> 6.4.1'
 end


### PR DESCRIPTION
## LinkKit V12.6.0 — 2025-10-06

#### Requirements

This SDK now works with any supported version of React Native.

### Changes

- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
- Upgrade to Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
- Upgrade to iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)

### Android

Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)

### Additions

- None

### Changes

- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.

### Removals

- None

#### Requirements

| Name | Version |
|------|---------|
| Android Studio | 4.0+ |
| Kotlin | 1.9.25+ (Kotlin integrations only) |

### iOS

iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)

### Changes

- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.

#### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |

