### PR TITLE
Update link_token docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ For iOS OAuth to work, specific requirements must be met.
 
 ##### Link Token OAuth Requirements
 
-- On iOS you must configure your `link_token` with a [redirect_uri](https://plaid.com/docs/api/tokens/#link-token-create-request-redirect-uri) to support OAuth. When creating a `link_token` for initializing Link on Android, `android_package_name` must be specified and `redirect_uri` must be left blank.
+- On iOS you must configure your `link_token` with a [redirect_uri](https://plaid.com/docs/api/link/#link-token-create-request-redirect-uri) to support OAuth. When creating a `link_token` for initializing Link on Android, `android_package_name` must be specified and `redirect_uri` must be left blank.
 
-- On Android you must configure your `link_token` with an [android_package_name](https://plaid.com/docs/api/tokens/#link-token-create-request-android-package-name) to support OAuth. When creating a `link_token` for initializing Link on iOS, `android_package_name` must be left blank and `redirect_uri` should be used instead.
+- On Android you must configure your `link_token` with an [android_package_name](https://plaid.com/docs/api/link/#link-token-create-request-android-package-name) to support OAuth. When creating a `link_token` for initializing Link on iOS, `android_package_name` must be left blank and `redirect_uri` should be used instead.
 
 
 #### To receive onEvent callbacks:


### PR DESCRIPTION
The OAuth setup section linked \`redirect_uri\` and \`android_package_name\` under \`https://plaid.com/docs/api/tokens/#...\`, which 404s now that Plaid migrated the Link Token reference under \`https://plaid.com/docs/api/link/\`. Both anchors (\`#link-token-create-request-redirect-uri\` and \`#link-token-create-request-android-package-name\`) still resolve on the new page.

## Test plan
- [ ] Click both links in the rendered README and confirm they scroll to the correct sections of the Link API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c