### PR TITLE
[Release] - 12.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # RELEASES
 
+## LinkKit V12.8.1 — 2026-05-27
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Upgrade to Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Additions
+
+- None
+
+### Changes
+
+- Remove kotlin.Metadata consumer proguard rule.
+- Fix flutter reporting.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- No changes.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
 ## LinkKit V12.8.0 — 2026-02-18
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.8.1            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.0            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.7.0            | *                        | [5.5.0+]    | 21                  | 34                     | >=6.4.2 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.6.1            | *                        | [5.4.0+]    | 21                  | 34                     | >=6.4.2 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.5.1"
+    implementation "com.plaid.link:sdk-core:5.5.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.8.0" />
+      android:value="12.8.1" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.8.0"; // SDK_VERSION
+    return @"12.8.1"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.8.0",
+  "version": "12.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "12.8.0",
+      "version": "12.8.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.8.0",
+  "version": "12.8.1",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release bumping the Android SDK from 5.5.1 → [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2). No TypeScript or iOS changes.

### Android SDK 5.5.2 changes
  - Remove `kotlin.Metadata` consumer proguard rule
  - Fix flutter reporting

## Files changed
  - `android/build.gradle` — `sdk-core:5.5.1` → `sdk-core:5.5.2`
  - `package.json` / `package-lock.json` — `12.8.0` → `12.8.1`
  - `ios/RNLinksdk.mm` — SDK_VERSION string
  - `android/src/main/AndroidManifest.xml` — meta-data version
  - `README.md` — new row in version compatibility table
  - `CHANGELOG.md` — new `LinkKit V12.8.1` section