### PR TITLE
[Fix] - Add iOS key to Codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,13 @@
     "jsSrcsDir": "./src/fabric",
     "android": {
       "javaPackageName": "com.plaid"
+    },
+    "ios": {
+      "modules": {
+        "RNLinksdk": {
+          "className": "RNLinksdk"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves issue [902](https://github.com/plaid/react-native-plaid-link-sdk/issues/902)