### PR TITLE
[Release] - 12.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # RELEASES
 
+## LinkKit V12.8.1 — 2026-06-01
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- **[Removed the redundant package="com.plaid" attribute from android/src/main/AndroidManifest.xml (#910)](https://github.com/plaid/react-native-plaid-link-sdk/commit/6f0807264701cee9d823561d436a5271eb04ad7c)**
+- **[remove example package.lock files (#911)](https://github.com/plaid/react-native-plaid-link-sdk/commit/401ca6a6b5b730a127937b1e82b2c1f8da44ee14)**
+- **[add ios key to codegen (#909)](https://github.com/plaid/react-native-plaid-link-sdk/commit/0dc4871f64d643d6d34699da0fab46d6a0c68abd)**
+- **[Deprecate SIIP and create SIPP in LinkAccountSubtypeInvestment (#908)](https://github.com/plaid/react-native-plaid-link-sdk/commit/be062a5be619ec4856c2ece023b49584ea12ab5f)**
+- **[fix LinkAccountSubtypeLoan using LinkAccountType.CREDIT (#907)](https://github.com/plaid/react-native-plaid-link-sdk/commit/42551c839ba0dd0e5b5fcf082bc0115da5a8ea1a)**
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Additions
+
+- None
+
+### Changes
+
+- Remove kotlin.Metadata consumer proguard rule.
+- Fix flutter reporting.
+
+### Removals
+
+- None
+
+#### Requirements
+
+
+| Name           | Version                            |
+| -------------- | ---------------------------------- |
+| Android Studio | 4.0+                               |
+| Kotlin         | 1.9.25+ (Kotlin integrations only) |
+
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- No changes.
+
+#### Requirements
+
+
+| Name  | Version   |
+| ----- | --------- |
+| Xcode | >= 16.1.0 |
+| iOS   | >= 14.0   |
+
+
 ## LinkKit V12.8.1 — 2026-05-27
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.8.2            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.1            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.0            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.7.0            | *                        | [5.5.0+]    | 21                  | 34                     | >=6.4.2 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.8.1" />
+      android:value="12.8.2" />
   </application>
 
 </manifest>

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -28,7 +28,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.8.1"; // SDK_VERSION
+    return @"12.8.2"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.8.1",
+  "version": "12.8.2",
   "description": "React Native Plaid Link SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## LinkKit V12.8.1 — 2026-06-01

#### Requirements

This SDK now works with any supported version of React Native.

### Changes

- **[Removed the redundant package="com.plaid" attribute from android/src/main/AndroidManifest.xml (#910)](https://github.com/plaid/react-native-plaid-link-sdk/commit/6f0807264701cee9d823561d436a5271eb04ad7c)**
- **[remove example package.lock files (#911)](https://github.com/plaid/react-native-plaid-link-sdk/commit/401ca6a6b5b730a127937b1e82b2c1f8da44ee14)**
- **[add ios key to codegen (#909)](https://github.com/plaid/react-native-plaid-link-sdk/commit/0dc4871f64d643d6d34699da0fab46d6a0c68abd)**
- **[Deprecate SIIP and create SIPP in LinkAccountSubtypeInvestment (#908)](https://github.com/plaid/react-native-plaid-link-sdk/commit/be062a5be619ec4856c2ece023b49584ea12ab5f)**
- **[fix LinkAccountSubtypeLoan using LinkAccountType.CREDIT (#907)](https://github.com/plaid/react-native-plaid-link-sdk/commit/42551c839ba0dd0e5b5fcf082bc0115da5a8ea1a)**

### Android

Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)

### Additions

- None

### Changes

- Remove kotlin.Metadata consumer proguard rule.
- Fix flutter reporting.

### Removals

- None

#### Requirements


| Name           | Version                            |
| -------------- | ---------------------------------- |
| Android Studio | 4.0+                               |
| Kotlin         | 1.9.25+ (Kotlin integrations only) |


### iOS

iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)

### Changes

- No changes.

#### Requirements


| Name  | Version   |
| ----- | --------- |
| Xcode | >= 16.1.0 |
| iOS   | >= 14.0   |