### PR TITLE
Fix package entrypoints and add package sanity check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   env: {
+    es6: true,
     node: true,
     jest: true,
   },

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js 19
+      - name: Use Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 19
+          node-version: 22
           cache: "npm"
 
       - name: Install Node modules
         run: npm ci --legacy-peer-deps
+
+      - name: Build TypeScript output
+        run: npm run build
 
       - name: Package sanity checks
         run: npm run check:package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,10 +1,10 @@
-name: Pull Request into Develop
+name: Pull Request
 
 on:
-  # Triggers the workflow on a pull request pointed at develop.
+  # Triggers the workflow on a pull request pointed at master.
   pull_request:
     branches:
-      - "develop"
+      - "master"
   
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
@@ -25,6 +25,9 @@ jobs:
 
       - name: Install Node modules
         run: npm ci
+
+      - name: Package sanity checks
+        run: npm run check:package
 
       - name: Linting
         run: npm run lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
           cache: "npm"
 
       - name: Install Node modules
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Package sanity checks
         run: npm run check:package

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "src/**/*"
   ],
   "scripts": {
+    "build": "tsc",
     "check:package": "node scripts/check-package-entrypoints.js",
     "lint": "eslint \"*.js\" \"scripts/**/*.js\" --fix",
     "prettier": "prettier \"./**/*.{js,jsx}\" --write",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-native-plaid-link-sdk",
   "version": "12.8.2",
   "description": "React Native Plaid Link SDK",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "react-native": "src/index.ts",
   "files": [
     "dist/**/*",
@@ -13,7 +13,8 @@
     "src/**/*"
   ],
   "scripts": {
-    "lint": "eslint \"./**/*.{js,jsx}\" --fix",
+    "check:package": "node scripts/check-package-entrypoints.js",
+    "lint": "eslint \"*.js\" \"scripts/**/*.js\" --fix",
     "prettier": "prettier \"./**/*.{js,jsx}\" --write",
     "test": "jest"
   },
@@ -36,7 +37,10 @@
   "jest": {
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/example/"
+      "/dist/",
+      "/example/",
+      "/FabricExample/",
+      "/exampleReactNative76/"
     ]
   },
   "author": "Plaid",

--- a/scripts/check-package-entrypoints.js
+++ b/scripts/check-package-entrypoints.js
@@ -1,0 +1,87 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(root, 'package.json');
+const packageJson = require(packageJsonPath);
+
+function fail(message) {
+  console.error(`Package entrypoint check failed: ${message}`);
+  process.exit(1);
+}
+
+function assertPackageFieldExists(fieldName) {
+  const fieldValue = packageJson[fieldName];
+
+  if (typeof fieldValue !== 'string' || fieldValue.length === 0) {
+    fail(`package.json field "${fieldName}" must be a non-empty string.`);
+  }
+
+  const absolutePath = path.join(root, fieldValue);
+
+  if (!fs.existsSync(absolutePath)) {
+    fail(
+      `package.json field "${fieldName}" points to a missing file: ${fieldValue}`,
+    );
+  }
+
+  return fieldValue;
+}
+
+const main = assertPackageFieldExists('main');
+const types = assertPackageFieldExists('types');
+
+try {
+  const resolved = require.resolve(root);
+  const expected = path.join(root, main);
+
+  if (resolved !== expected) {
+    fail(
+      `require.resolve('.') resolved to ${path.relative(
+        root,
+        resolved,
+      )}, expected ${main}`,
+    );
+  }
+} catch (error) {
+  fail(`require.resolve('.') failed: ${error.message}`);
+}
+
+let packOutput;
+
+try {
+  packOutput = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_cache: path.join(
+        os.tmpdir(),
+        'react-native-plaid-link-sdk-npm-cache',
+      ),
+    },
+  });
+} catch (error) {
+  fail(`npm pack --dry-run --json failed:\n${error.stderr || error.message}`);
+}
+
+let packResult;
+
+try {
+  packResult = JSON.parse(packOutput);
+} catch (error) {
+  fail(`npm pack did not return valid JSON: ${error.message}`);
+}
+
+const packedFiles = (packResult[0] && packResult[0].files) || [];
+const files = new Set(packedFiles.map(file => file.path));
+
+for (const entrypoint of [main, types]) {
+  if (!files.has(entrypoint)) {
+    fail(`packed package does not include ${entrypoint}`);
+  }
+}
+
+console.log(`Package entrypoints are valid: ${main}, ${types}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "src/__tests__",
     "babel.config.js",
     "metro.config.js",
     "jest.config.js",


### PR DESCRIPTION
## Summary
- point package `main` and `types` at the emitted `dist/src/index.*` files
- add `npm run check:package` to verify entrypoints exist and are included in `npm pack --dry-run`
- run PR CI against `master` and keep root lint/Jest checks focused on the SDK package

## Testing
- `npm run lint`
- `npm run check:package`
- `npm test`