### PR TITLE
Add v13 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ React Native Plaid Link SDK (New Architecture & Expo)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/react-native-plaid-link-sdk/)
 - [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/react-native-plaid-link-sdk/)
 
+# Migration guides
+
+- [v13 migration guide](./V13_MIGRATION_GUIDE.md)
+
 # Installation in managed Expo projects
 
 For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.

--- a/V13_MIGRATION_GUIDE.md
+++ b/V13_MIGRATION_GUIDE.md
@@ -1,33 +1,470 @@
 # React Native Plaid Link SDK v13 Migration Guide
 
-This guide covers breaking changes introduced in `react-native-plaid-link-sdk` v13 and how to update your integration.
+This guide covers the breaking changes introduced in `react-native-plaid-link-sdk`
+v13 and shows how to migrate from v11 or v12 integrations.
 
-## Breaking Changes
+## Quick Links
+
+- [Why Upgrade](#why-upgrade)
+- [Overview](#overview)
+- [Installation and Tooling](#installation-and-tooling)
+- [Standard Link Migration](#standard-link-migration)
+- [Event and Callback Migration](#event-and-callback-migration)
+- [Layer Migration](#layer-migration)
+- [Headless Link Migration](#headless-link-migration)
+- [Embedded Search Migration](#embedded-search-migration)
+- [FinanceKit Migration](#financekit-migration)
+- [Other Breaking Changes](#other-breaking-changes)
+
+## Why Upgrade
+
+v13 rebuilds the React Native SDK on Expo Modules and updates the native Link
+integrations. This gives the SDK a single module implementation for Expo and
+bare React Native apps, adds session-based APIs, and brings Android Embedded
+Search support into the public React Native API.
+
+## Overview
+
+v13 changes the JavaScript API from global `create`, `open`, `submit`, and event
+emitter helpers to explicit session objects:
+
+| v11/v12 API | v13 replacement |
+| --- | --- |
+| `PlaidLink` component | Create your own button and call `createPlaidLinkSession` |
+| `openLink(...)` | `const session = await createPlaidLinkSession(...); await session.open()` |
+| `create(...)` then `open(...)` | `const session = await createPlaidLinkSession(...); await session.open()` |
+| `usePlaidEmitter(...)` | Pass `onEvent` to the session creation function |
+| `submit(...)` | `session.submit(...)` from a `PlaidLayerSession` |
+| `EmbeddedLinkView` | `PlaidEmbeddedSearchView` |
+| callback-style `syncFinanceKit(...)` | promise-returning `syncFinanceKit({ ... })` |
+
+The public import path is unchanged:
+
+```ts
+import { createPlaidLinkSession } from "react-native-plaid-link-sdk";
+```
+
+## Installation and Tooling
+
+v13 is an Expo Module package. Bare React Native apps must have Expo Modules
+installed and configured before installing this SDK.
+
+```sh
+npm install react-native-plaid-link-sdk expo
+npx pod-install
+```
+
+If your app is already an Expo app or already has Expo Modules installed, install
+or upgrade only this package:
+
+```sh
+npm install react-native-plaid-link-sdk@^13
+npx pod-install
+```
+
+v13 publishes JavaScript and TypeScript declarations from `build/index.js` and
+`build/index.d.ts`. Apps should continue importing from
+`react-native-plaid-link-sdk`; do not import from `build/`, `src/`, `ios/`, or
+`android/` directly.
+
+## Standard Link Migration
+
+### v11 `openLink` or `PlaidLink`
+
+Before v13, older v11 integrations could open Link with `openLink` or the
+deprecated `PlaidLink` component.
+
+Before:
+
+```ts
+import {
+  LinkIOSPresentationStyle,
+  LinkLogLevel,
+  openLink,
+} from "react-native-plaid-link-sdk";
+
+openLink({
+  tokenConfig: {
+    token: "#GENERATED_LINK_TOKEN#",
+    logLevel: LinkLogLevel.ERROR,
+    noLoadingState: false,
+  },
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  iOSPresentationStyle: LinkIOSPresentationStyle.MODAL,
+});
+```
+
+After:
+
+```ts
+import { createPlaidLinkSession } from "react-native-plaid-link-sdk";
+
+const session = await createPlaidLinkSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  onEvent: (event) => {
+    console.log("Event", event);
+  },
+});
+
+await session.open(false);
+```
+
+### v12 `create` and `open`
+
+v12 integrations usually preloaded Link with `create(...)` and opened it later
+with `open(...)`.
+
+Before:
+
+```ts
+import {
+  LinkIOSPresentationStyle,
+  LinkLogLevel,
+  create,
+  open,
+} from "react-native-plaid-link-sdk";
+
+create({
+  token: "#GENERATED_LINK_TOKEN#",
+  logLevel: LinkLogLevel.ERROR,
+  noLoadingState: false,
+  onLoad: () => {
+    console.log("Link loaded");
+  },
+});
+
+open({
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  iOSPresentationStyle: LinkIOSPresentationStyle.MODAL,
+});
+```
+
+After:
+
+```ts
+import { createPlaidLinkSession } from "react-native-plaid-link-sdk";
+
+const session = await createPlaidLinkSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  onEvent: (event) => {
+    console.log("Event", event);
+  },
+  onLoad: () => {
+    console.log("Link loaded");
+  },
+});
+
+await session.open(false);
+```
+
+`session.open(false)` presents Link using the default presentation. Pass `true`
+to request full-screen presentation.
+
+## Event and Callback Migration
+
+`usePlaidEmitter` has been removed. In v13, each session creation function takes
+its own callbacks. This keeps callback ownership tied to the active Link session.
+
+Before:
+
+```ts
+import { usePlaidEmitter } from "react-native-plaid-link-sdk";
+
+usePlaidEmitter((event) => {
+  console.log("Event", event);
+});
+```
+
+After:
+
+```ts
+const session = await createPlaidLinkSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess,
+  onExit,
+  onEvent: (event) => {
+    console.log("Event", event);
+  },
+});
+```
+
+The native module uses namespaced internal event names:
+
+- `PlaidLink.onSuccess`
+- `PlaidLink.onExit`
+- `PlaidLink.onEvent`
+
+These names are implementation details. App code should use the callback
+properties passed to `createPlaidLinkSession`, `createPlaidLayerSession`,
+`createPlaidHeadlessSession`, or `PlaidEmbeddedSearchView`.
+
+### Callback payload changes
+
+`metadataJson` is the canonical metadata JSON field in v13 callback payloads:
+
+```ts
+onEvent: (event) => {
+  console.log(event.metadata.metadataJson);
+};
+```
+
+If your v11 or v12 TypeScript code references `metadata_json`, update it to
+`metadataJson`. This aligns `LinkEventMetadata` with the rest of the callback
+payload keys, such as `eventName`, `linkSessionId`, `requestId`, and `viewName`.
+
+`errorDisplayMessage` has also been removed from `LinkError`. Use
+`displayMessage` instead:
+
+```ts
+onExit: (exit) => {
+  console.log(exit.error?.displayMessage);
+};
+```
+
+## Layer Migration
+
+Layer now uses a dedicated session object.
+
+Before:
+
+```ts
+import { create, open, submit } from "react-native-plaid-link-sdk";
+
+create({
+  token: "#GENERATED_LINK_TOKEN#",
+  noLoadingState: true,
+});
+
+submit({
+  phoneNumber: "415-555-0017",
+  dateOfBirth: "1975-01-18",
+});
+
+open({
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+});
+```
+
+After:
+
+```ts
+import {
+  LinkEventName,
+  PlaidLayerSession,
+  createPlaidLayerSession,
+} from "react-native-plaid-link-sdk";
+
+let session: PlaidLayerSession;
+
+session = await createPlaidLayerSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  onEvent: async (event) => {
+    if (event.eventName === LinkEventName.LAYER_READY) {
+      await session.open();
+    }
+  },
+});
+
+await session.submit({
+  phoneNumber: "415-555-0017",
+  dateOfBirth: "1975-01-18",
+});
+```
+
+If your Layer flow only requires a phone number, omit `dateOfBirth`:
+
+```ts
+await session.submit({
+  phoneNumber: "415-555-0015",
+});
+```
+
+## Headless Link Migration
+
+Headless Link is new in v13. Create a headless session, then call `start()`.
+
+```ts
+import { createPlaidHeadlessSession } from "react-native-plaid-link-sdk";
+
+const session = await createPlaidHeadlessSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  onEvent: (event) => {
+    console.log("Event", event);
+  },
+  onLoad: () => {
+    console.log("Headless session loaded");
+  },
+});
+
+await session.start();
+```
+
+## Embedded Search Migration
+
+v11 and v12 exported `EmbeddedLinkView`. v13 exports
+`PlaidEmbeddedSearchView` instead. Android Embedded Search is supported in v13.
+
+Before:
+
+```tsx
+import { EmbeddedLinkView } from "react-native-plaid-link-sdk";
+
+<EmbeddedLinkView
+  token="#GENERATED_LINK_TOKEN#"
+  onSuccess={(success) => {
+    console.log("Success", success);
+  }}
+  onExit={(exit) => {
+    console.log("Exit", exit);
+  }}
+/>;
+```
+
+After:
+
+```tsx
+import { PlaidEmbeddedSearchView } from "react-native-plaid-link-sdk";
+
+<PlaidEmbeddedSearchView
+  token="#GENERATED_LINK_TOKEN#"
+  style={{ height: 500 }}
+  onLoad={() => {
+    console.log("Embedded Search loaded");
+  }}
+  onSuccess={(success) => {
+    console.log("Success", success);
+  }}
+  onExit={(exit) => {
+    console.log("Exit", exit);
+  }}
+  onEvent={(event) => {
+    console.log("Event", event);
+  }}
+/>;
+```
+
+## FinanceKit Migration
+
+FinanceKit remains iOS-only. In v12, `syncFinanceKit` accepted positional
+arguments and reported completion through a callback. In v13, it accepts a
+configuration object and returns a promise.
+
+Before:
+
+```ts
+import { syncFinanceKit } from "react-native-plaid-link-sdk";
+
+syncFinanceKit(
+  "#GENERATED_LINK_TOKEN#",
+  true,
+  false,
+  (error) => {
+    if (error) {
+      console.log("FinanceKit error", error);
+      return;
+    }
+
+    console.log("FinanceKit sync complete");
+  }
+);
+```
+
+After:
+
+```ts
+import {
+  FinanceKitSyncBehavior,
+  syncFinanceKit,
+} from "react-native-plaid-link-sdk";
+
+try {
+  await syncFinanceKit({
+    token: "#GENERATED_LINK_TOKEN#",
+    requestAuthorizationIfNeeded: true,
+    syncBehavior: FinanceKitSyncBehavior.LIVE,
+  });
+
+  console.log("FinanceKit sync complete");
+} catch (error) {
+  console.log("FinanceKit error", error);
+}
+```
+
+Calling `syncFinanceKit` on Android rejects with an error because FinanceKit is
+only available on iOS.
+
+## Other Breaking Changes
 
 ### `LinkAccountSubtypeInvestment.SIIP` renamed to `SIPP`
 
-The misspelled investment account subtype constant `LinkAccountSubtypeInvestment.SIIP` has been removed and replaced with the correctly spelled `LinkAccountSubtypeInvestment.SIPP` (Self-Invested Personal Pension).
+The misspelled investment account subtype constant
+`LinkAccountSubtypeInvestment.SIIP` has been removed and replaced with the
+correctly spelled `LinkAccountSubtypeInvestment.SIPP` (Self-Invested Personal
+Pension).
 
-The underlying runtime value is unchanged (`"sipp"`), so this is a compile-time rename only. No behavior changes for accounts that were already filtered correctly.
+The underlying runtime value is unchanged (`"sipp"`), so this is a compile-time
+rename only. There is no behavior change for accounts that were already filtered
+correctly.
 
-Before (v12 and earlier):
+Before:
 
 ```ts
-import { LinkAccountSubtypeInvestment } from 'react-native-plaid-link-sdk';
+import { LinkAccountSubtypeInvestment } from "react-native-plaid-link-sdk";
 
 const subtypes = [LinkAccountSubtypeInvestment.SIIP];
 ```
 
-After (v13):
+After:
 
 ```ts
-import { LinkAccountSubtypeInvestment } from 'react-native-plaid-link-sdk';
+import { LinkAccountSubtypeInvestment } from "react-native-plaid-link-sdk";
 
 const subtypes = [LinkAccountSubtypeInvestment.SIPP];
 ```
 
-Action required: replace any usage of `LinkAccountSubtypeInvestment.SIIP` with `LinkAccountSubtypeInvestment.SIPP`. TypeScript will surface the removed member as a compile error:
+Action required: replace any usage of `LinkAccountSubtypeInvestment.SIIP` with
+`LinkAccountSubtypeInvestment.SIPP`. TypeScript will surface the removed member
+as a compile error:
 
-```
+```text
 Property 'SIIP' does not exist on type 'typeof LinkAccountSubtypeInvestment'. Did you mean 'SIPP'?
 ```

--- a/src/ReactNativePlaidLinkSdk.types.ts
+++ b/src/ReactNativePlaidLinkSdk.types.ts
@@ -637,7 +637,7 @@ export interface LinkEventMetadata {
   // see possible values for selection at https://plaid.com/docs/link/web/#link-web-onevent-selection
   selection?: null | string;
   timestamp: string;
-  metadata_json: string;
+  metadataJson: string;
 }
 
 export enum LinkEventName {

--- a/src/__tests__/createPlaidHeadlessSession.test.ts
+++ b/src/__tests__/createPlaidHeadlessSession.test.ts
@@ -110,7 +110,7 @@ describe("createPlaidHeadlessSession", () => {
         linkSessionId: "session-123",
         viewName: "CONNECTED" as any,
         timestamp: "2026-03-27T12:00:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 

--- a/src/__tests__/createPlaidLayerSession.test.ts
+++ b/src/__tests__/createPlaidLayerSession.test.ts
@@ -74,7 +74,7 @@ describe("createPlaidLayerSession", () => {
         linkSessionId: "session-123",
         viewName: "CONNECTED" as any,
         timestamp: "2026-03-27T12:00:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 

--- a/src/__tests__/createPlaidLinkSession.test.ts
+++ b/src/__tests__/createPlaidLinkSession.test.ts
@@ -186,7 +186,7 @@ describe("createPlaidLinkSession", () => {
         linkSessionId: "session-123",
         viewName: "CONNECTED" as any,
         timestamp: "2026-03-27T12:00:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 
@@ -196,7 +196,7 @@ describe("createPlaidLinkSession", () => {
         linkSessionId: "session-123",
         viewName: "SELECT_INSTITUTION" as any,
         timestamp: "2026-03-27T12:01:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 

--- a/src/__tests__/listener-lifecycle.test.ts
+++ b/src/__tests__/listener-lifecycle.test.ts
@@ -162,7 +162,7 @@ describe("Listener Lifecycle", () => {
         linkSessionId: "session-1",
         viewName: "EXIT" as any,
         timestamp: "2026-03-27T12:00:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 
@@ -212,7 +212,7 @@ describe("Listener Lifecycle", () => {
         linkSessionId: "session-1",
         viewName: "CONNECTED" as any,
         timestamp: "2026-03-27T12:00:00Z",
-        metadata_json: "{}",
+        metadataJson: "{}",
       },
     };
 
@@ -242,7 +242,7 @@ describe("Listener Lifecycle", () => {
           linkSessionId: "session-1",
           viewName: "CONNECTED" as any,
           timestamp: "2026-03-27T12:00:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       },
       {
@@ -251,7 +251,7 @@ describe("Listener Lifecycle", () => {
           linkSessionId: "session-1",
           viewName: "SELECT_INSTITUTION" as any,
           timestamp: "2026-03-27T12:01:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       },
       {
@@ -260,7 +260,7 @@ describe("Listener Lifecycle", () => {
           linkSessionId: "session-1",
           viewName: "CREDENTIAL" as any,
           timestamp: "2026-03-27T12:02:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       },
       {
@@ -269,7 +269,7 @@ describe("Listener Lifecycle", () => {
           linkSessionId: "session-1",
           viewName: "MFA" as any,
           timestamp: "2026-03-27T12:03:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       },
       {
@@ -278,7 +278,7 @@ describe("Listener Lifecycle", () => {
           linkSessionId: "session-1",
           viewName: "CONNECTED" as any,
           timestamp: "2026-03-27T12:04:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       },
     ];

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -295,7 +295,7 @@ describe("Type Definitions", () => {
           linkSessionId: "session-123",
           viewName: "SELECT_INSTITUTION" as any,
           timestamp: "2026-03-27T12:00:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
           institutionId: "inst-1",
           institutionName: "Test Bank",
         },
@@ -305,7 +305,7 @@ describe("Type Definitions", () => {
       expect(linkEvent.metadata.linkSessionId).toBeDefined();
       expect(linkEvent.metadata.viewName).toBeDefined();
       expect(linkEvent.metadata.timestamp).toBeDefined();
-      expect(linkEvent.metadata.metadata_json).toBeDefined();
+      expect(linkEvent.metadata.metadataJson).toBeDefined();
     });
 
     it("LinkAccount has verification status", () => {
@@ -520,7 +520,7 @@ describe("Type Definitions", () => {
           institutionName: "Test Bank",
           institutionSearchQuery: "test",
           timestamp: "2026-03-27T12:00:00Z",
-          metadata_json: "{}",
+          metadataJson: "{}",
         },
       };
 


### PR DESCRIPTION
## Summary
- expand the v13 migration guide for v11/v12 integrations
- document session-based APIs, Expo Modules setup, callback payload changes, Layer, Headless, Embedded Search, FinanceKit, and SIIP -> SIPP
- align LinkEventMetadata with native callback payloads by renaming metadata_json to metadataJson
- add a README link to the v13 migration guide

## Validation
- PATH=/Users/dtroupe/.nvm/versions/node/v20.19.4/bin:$PATH npm test -- --coverage --no-watch --passWithNoTests
- PATH=/Users/dtroupe/.nvm/versions/node/v20.19.4/bin:$PATH npm run build
- git diff --check