### PR TITLE
Prepare v13 package for release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,6 +39,16 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
+      - name: Build package
+        run: npm run build
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+
+      - name: Package sanity check
+        run: npm run check:package
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,8 @@ __mocks__
 __tests__
 
 /babel.config.js
+/coverage/
+/dist/
 /android/src/androidTest/
 /android/src/test/
 /android/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,70 +1,1458 @@
-# Changelog
+# RELEASES
 
-## 13.0.0 - 2026-06-26
+## LinkKit V13.0.0 — 2026-06-26
 
-v13 is a major release that rebuilds the React Native SDK on Expo Modules,
-updates the native Link integrations to iOS LinkKit 7.0.0 and Android
-`sdk-core` 6.0.0, and introduces a session-based JavaScript API for Link flows.
+#### Requirements
 
-For detailed migration examples, see [V13_MIGRATION_GUIDE.md](./V13_MIGRATION_GUIDE.md).
+This SDK now works with any supported version of React Native that supports Expo
+Modules. Expo Go is not supported because Plaid Link requires custom native
+code; Expo apps should use a development build or another custom native runtime.
 
-### Breaking Changes
+### Changes
 
-- Replaced the legacy global `create`, `open`, `submit`, `openLink`,
-  `PlaidLink`, and `usePlaidEmitter` APIs with explicit session objects:
+- Rebuilds the React Native SDK on Expo Modules.
+- Replaces the legacy global `create`, `open`, `submit`, `openLink`,
+  `PlaidLink`, and `usePlaidEmitter` APIs with session objects:
   `createPlaidLinkSession`, `createPlaidLayerSession`, and
   `createPlaidHeadlessSession`.
-- Rebuilt the package as an Expo Module. Bare React Native apps must install and
-  configure Expo Modules before using v13.
-- Expo Go is not supported because Plaid Link requires custom native code. Expo
-  apps should use a development build or another custom native runtime.
-- Standard Link, Layer, and Headless callbacks are now registered per session
-  instead of through a shared event emitter.
-- `metadataJson` is the canonical callback metadata field. Update stale
+- Adds `PlaidEmbeddedSearchView` for Embedded Search on iOS and Android.
+- Adds Headless Link support through `createPlaidHeadlessSession`.
+- Updates Layer to use `createPlaidLayerSession`, `session.open()`, and
+  `session.submit({ phoneNumber, dateOfBirth, params })`.
+- Updates `syncFinanceKit` to a promise API. FinanceKit remains iOS-only and
+  rejects on Android.
+- Uses `metadataJson` as the canonical callback metadata field. Update stale
   `metadata_json` references from v11 or v12 TypeScript code.
-- Removed `errorDisplayMessage` from `LinkError`. Use `displayMessage` instead.
-- `syncFinanceKit` now returns a promise and remains iOS-only. Android calls
-  reject with an unsupported-platform error.
-- Renamed `LinkAccountSubtypeInvestment.SIIP` to
+- Removes `errorDisplayMessage` from `LinkError`; use `displayMessage`.
+- Renames `LinkAccountSubtypeInvestment.SIIP` to
   `LinkAccountSubtypeInvestment.SIPP`.
-
-### Native SDK Updates
-
-- Updated iOS to LinkKit 7.0.0, including the new session-based LinkKit API,
-  `PlaidLinkSession`, `PlaidLayerSession`, `PlaidHeadlessSession`,
-  first-class `onLoad` handling, native Embedded Search, and the modernized
-  FinanceKit sync API.
-- Updated Android to `com.plaid.link:sdk-core:6.0.0`, including the native
-  session APIs, Layer submit support, Headless Link support, and Embedded Search
-  continuation support.
-
-### New APIs
-
-- Added `createPlaidLinkSession({ token, onSuccess, onExit, onEvent, onLoad })`
-  for Standard Link.
-- Added `createPlaidLayerSession({ token, onSuccess, onExit, onEvent })` with
-  `session.open()` and `session.submit({ phoneNumber, dateOfBirth, params })`.
-- Added `createPlaidHeadlessSession({ token, onSuccess, onExit, onEvent })`
-  with `session.start()`.
-- Added `PlaidEmbeddedSearchView` for Embedded Search on iOS and Android.
-- Added promise-based `syncFinanceKit({ token, requestAuthorizationIfNeeded,
-  syncBehavior })` for iOS.
-
-### Package and Distribution
-
-- v13 publishes JavaScript and TypeScript entrypoints from `build/index.js` and
+- Publishes JavaScript and TypeScript entrypoints from `build/index.js` and
   `build/index.d.ts`.
-- v13 ships the bundled iOS `LinkKit.xcframework` in the npm package because
+- Ships the bundled iOS `LinkKit.xcframework` in the npm package because
   LinkKit 7 no longer supports CocoaPods distribution. This intentionally
   increases the npm tarball size compared with v12.
-- Excluded generated example projects, coverage output, and stale `dist` output
+- Excludes generated example projects, coverage output, and stale `dist` output
   from the npm package.
-- Added package sanity checks to CI to verify entrypoints exist and are included
-  in the packed npm tarball.
-
-### Fixes
-
-- Aligned iOS fallback `onExit` payloads with the public React Native callback
+- Adds CI package sanity checks to verify package entrypoints and packed npm
+  contents.
+- Aligns iOS fallback `onExit` payloads with the public React Native callback
   contract by emitting `{ error, metadata }`.
-- Added callback contract tests to catch iOS, Android, or TypeScript payload
+- Adds callback contract tests to catch iOS, Android, or TypeScript payload
   shape drift.
+
+For detailed migration examples, see
+[V13_MIGRATION_GUIDE.md](./V13_MIGRATION_GUIDE.md).
+
+### Android
+
+Android SDK [6.0.0](https://github.com/plaid/plaid-link-android)
+
+### Additions
+
+- Adds native session APIs for Standard Link, Layer, and Headless Link.
+- Adds Embedded Search continuation support.
+- Adds Layer submit support.
+
+### Changes
+
+- Updates Android integration to `com.plaid.link:sdk-core:6.0.0`.
+
+### Removals
+
+- Removes the legacy React Native Android bridge implementation.
+
+#### Requirements
+
+| Name           | Version                            |
+| -------------- | ---------------------------------- |
+| Android Studio | 4.0+                               |
+| Kotlin         | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [7.0.0](https://github.com/plaid/plaid-link-ios/releases/tag/7.0.0)
+
+### Changes
+
+- Updates to LinkKit 7.0.0.
+- Uses the new session-based LinkKit APIs for Standard Link, Layer, Headless
+  Link, and Embedded Search.
+- Uses the modernized FinanceKit sync API.
+- Bundles `LinkKit.xcframework` with the npm package for native iOS builds.
+
+#### Requirements
+
+| Name  | Version   |
+| ----- | --------- |
+| Xcode | >= 16.1.0 |
+| iOS   | >= 14.0   |
+
+## LinkKit V12.8.3 — 2026-06-11
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- **[Unable to resolve path to module 'react-native-plaid-link-sdk' #915)](https://github.com/plaid/react-native-plaid-link-sdk/issues/915)**
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Additions
+
+- None
+
+### Changes
+
+- Remove kotlin.Metadata consumer proguard rule.
+- Fix flutter reporting.
+
+### Removals
+
+- None
+
+#### Requirements
+
+
+| Name           | Version                            |
+| -------------- | ---------------------------------- |
+| Android Studio | 4.0+                               |
+| Kotlin         | 1.9.25+ (Kotlin integrations only) |
+
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- No changes.
+
+#### Requirements
+
+
+| Name  | Version   |
+| ----- | --------- |
+| Xcode | >= 16.1.0 |
+| iOS   | >= 14.0   |
+
+
+
+## LinkKit V12.8.2 — 2026-06-01
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- **[Removed the redundant package="com.plaid" attribute from android/src/main/AndroidManifest.xml (#910)](https://github.com/plaid/react-native-plaid-link-sdk/commit/6f0807264701cee9d823561d436a5271eb04ad7c)**
+- **[remove example package.lock files (#911)](https://github.com/plaid/react-native-plaid-link-sdk/commit/401ca6a6b5b730a127937b1e82b2c1f8da44ee14)**
+- **[add ios key to codegen (#909)](https://github.com/plaid/react-native-plaid-link-sdk/commit/0dc4871f64d643d6d34699da0fab46d6a0c68abd)**
+- **[Deprecate SIIP and create SIPP in LinkAccountSubtypeInvestment (#908)](https://github.com/plaid/react-native-plaid-link-sdk/commit/be062a5be619ec4856c2ece023b49584ea12ab5f)**
+- **[fix LinkAccountSubtypeLoan using LinkAccountType.CREDIT (#907)](https://github.com/plaid/react-native-plaid-link-sdk/commit/42551c839ba0dd0e5b5fcf082bc0115da5a8ea1a)**
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Additions
+
+- None
+
+### Changes
+
+- Remove kotlin.Metadata consumer proguard rule.
+- Fix flutter reporting.
+
+### Removals
+
+- None
+
+#### Requirements
+
+
+| Name           | Version                            |
+| -------------- | ---------------------------------- |
+| Android Studio | 4.0+                               |
+| Kotlin         | 1.9.25+ (Kotlin integrations only) |
+
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- No changes.
+
+#### Requirements
+
+
+| Name  | Version   |
+| ----- | --------- |
+| Xcode | >= 16.1.0 |
+| iOS   | >= 14.0   |
+
+
+
+## LinkKit V12.8.1 — 2026-05-27
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Upgrade to Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Additions
+
+- None
+
+### Changes
+
+- Remove kotlin.Metadata consumer proguard rule.
+- Fix flutter reporting.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- No changes.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.8.0 — 2026-02-18
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Adds missing LAYER_AUTOFILL_NOT_AVAILABLE event name on iOS
+- Adds support to submit layer params on iOS & Android
+
+### Android
+
+Android SDK [5.5.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.1)
+
+### Additions
+
+- None
+
+### Changes
+
+- Layer update.
+- Add missing proguard consumer rule.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.3](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.3)
+
+### Changes
+
+- Layer updates.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.7.0 — 2025-11-04
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Add `onLoad` to `LinkTokenConfiguration`, fired once when Link is fully loaded and ready to present. Use it to manage your own loading UI or defer presentation until ready.
+
+### Android
+
+Android SDK [5.5.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.0)
+
+### Additions
+
+- None
+
+### Changes
+
+- Made LinkErrorCode.errorType public.
+- Fixed bug where layer "auto" customization for light/dark mode was always dark, regardless of system setting.
+- Added onLoad callback to Plaid.create for detecting when Link is ready to present.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.2)
+
+### Changes
+
+- Resolved `syncFinanceKit` crash when running on iPad on compatibility mode.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.6.1 — 2025-10-22
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively. 
+- Upgrade to Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+- Upgrade to iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)
+
+### Android
+
+Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+
+### Additions
+
+- None
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.2)
+
+### Changes
+
+- Resolved `syncFinanceKit` crash when running on iPad on compatibility mode.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.6.0 — 2025-10-06
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively. 
+- Upgrade to Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+- Upgrade to iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)
+
+### Android
+
+Android SDK [5.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.4.0)
+
+### Additions
+
+- None
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.1)
+
+### Changes
+
+- Resolved an issue where the `selection` value was missing in `LinkEvent.EventMetadata`.
+- Improved internal debugging and logging to help diagnose customer-reported issues more effectively.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.5.3 — 2025-09-16
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [816](https://github.com/plaid/react-native-plaid-link-sdk/issues/816) with Android SDK upgrade to v5.3.4.
+
+### Android
+
+Android SDK [5.3.4](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.4)
+
+### Additions
+
+- None
+
+### Changes
+
+- Fix retrofit reinitialization bug in edge cases.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.5.2 — 2025-09-10
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [810](https://github.com/plaid/react-native-plaid-link-sdk/issues/810) Support for react native 0.81+
+- Adds `metadataJson` key to event data to allow for all keys to be camelCase.
+- Updates Android SDK
+
+
+### Android
+
+Android SDK [5.3.3](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.3)
+
+### Additions
+
+- None
+
+### Changes
+
+- Upgrade com.google.code.gson:gson to 2.9.1.
+- Upgrade com.squareup.okhttp3:logging-interceptor to 4.9.2.
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.5.1 — 2025-09-04
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [803](https://github.com/plaid/react-native-plaid-link-sdk/issues/803) Support for react native 0.81+
+
+
+### Android
+
+Android SDK [5.3.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.2)
+
+### Additions
+
+- Upgrade com.google.protobuf:protobuf-kotlin-lite to 3.25.5
+- Ensure SDK screens resize for keyboard insets on Android 15+
+
+### Changes
+
+- None
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.5.0 — 2025-09-04
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Updates Android SDK to the latest version.
+- Resolve issue [804](https://github.com/plaid/react-native-plaid-link-sdk/issues/804) bottom Navigation Bar Overlapping UI Elements
+
+
+### Android
+
+Android SDK [5.3.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.2)
+
+### Additions
+
+- Upgrade com.google.protobuf:protobuf-kotlin-lite to 3.25.5
+- Ensure SDK screens resize for keyboard insets on Android 15+
+
+### Changes
+
+- None
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.4.0 — 2025-08-06
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Updates Android and iOS SDKs to the latest versions.
+- metadata_json, issueId, issueDescription, issueDetectedAt to LinkEventMetadata.
+- Add dateOfBirth to SubmissionData.
+- Update submit APIs to allow for date of birth.
+- Add LAYER_AUTOFILL_NOT_AVAILABLE to LinkEventName.
+
+### Android
+
+Android SDK [5.3.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.0)
+
+### Additions
+
+- Add LAYER_AUTOFILL_NOT_AVAILABLE event.
+- Add issueDescription and issueDetectedAt at event metadata fields.
+- Update Layer submit API to support additional parameter dateOfBirth
+
+### Changes
+
+- None
+
+### Removals
+
+- None
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0)
+
+### Changes
+
+- Add issueDescription and issueDetectedAt to EventMetadata.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.3.2 — 2025-07-30
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)
+
+### Additions
+
+- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.
+
+### Changes
+
+- Improve destroy() API behavior in edge cases.
+
+### Removals
+
+- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
+- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.3.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.2)
+
+### Changes
+
+- Resolve XCFramework signing issue.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.3.1 — 2025-07-28
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)
+
+### Additions
+
+- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.
+
+### Changes
+
+- Improve destroy() API behavior in edge cases.
+
+### Removals
+
+- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
+- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.3.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.1)
+
+### Changes
+
+- Expose Finance Kit sync simulated behavior to Objective-C (React Native).
+- Updated Layer submit API
+- Added Layer event LAYER_AUTOFILL_NOT_AVAILABLE
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.3.0 — 2025-07-24
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.2.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.2.0)
+
+### Additions
+
+- Add ISSUE_FOLLOWED, IDENTITY_MATCH_PASSED, and IDENTITY_MATCH_FAILED event names and issue_id event metadata field.
+
+### Changes
+
+- Improve destroy() API behavior in edge cases.
+
+### Removals
+
+- Reduce SDK size by 11.5% down from 5.0MB to 4.5MB. 
+- Remove the androidx.recyclerview:recyclerview, androidx.constraintlayout:constraintlayout, and io.coil-kt:coil dependencies.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.3.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.3.0)
+
+### SwiftUI API Enhancements
+
+- Added `makePlaidLinkSheet()` to `Handler`: a convenience method that returns a `View` to present LinkKit using `.fullScreenCover` in SwiftUI applications.
+- Added `plaidLink(isPresented:handler:)`: a SwiftUI view modifier to attach LinkKit to any `View`, such as a `Button`, using a pre-configured handler.
+- Added `plaidLink(isPresented:token:onSuccess:onExit:onEvent:onLoad:errorView:)`: a flexible SwiftUI modifier for creating LinkKit sessions with just a link token and callbacks—no `Handler` required.
+
+### Testing
+
+- Improved FinanceKit testing capabilities in Sandbox.
+
+### Event Tracking Improvements
+
+- Added event names:
+  - `IDENTITY_MATCH_PASSED`
+  - `IDENTITY_MATCH_FAILED`
+  - `ISSUE_FOLLOWED`
+  - `SELECT_ACCOUNT`
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.2.1 — 2025-06-21
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Changes
+
+- Resolve issue [782 PLKEnvironmentDevelopment not defined](https://github.com/plaid/react-native-plaid-link-sdk/issues/782).
+
+### Android
+
+Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Add Flutter SDK version tracking.
+- Fixed edge to edge layout overlap issue in Android 15+.
+
+### Removals
+
+- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
+- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)
+
+#### Changes
+
+- Add Flutter SDK version tracking.
+- Reduced SDK size from 13.2MB to 8.9MB
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.2.0 — 2025-06-13
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.1.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.1.1)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Add Flutter SDK version tracking.
+- Fixed edge to edge layout overlap issue in Android 15+.
+
+### Removals
+
+- Reduced SDK size by 20%, from 6.2 MB down to 5.0 MB.
+- Removed org.bouncycastle:bcpkix-jdk15to18 dependency.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.9.25+ (Kotlin integrations only) |
+
+### iOS
+
+iOS SDK [6.2.1](https://github.com/plaid/plaid-link-ios/releases/tag/6.2.1)
+
+#### Changes
+
+- Add Flutter SDK version tracking.
+- Reduced SDK size from 13.2MB to 8.9MB
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.1.1 — 2025-04-03
+
+### React Native
+
+- Adds `destroy()` method for Android.
+- Remove `async` from open method.
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
+
+#### Changes
+
+- Improved RememberMe experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.1.0 — 2025-03-10
+
+### React Native
+
+- Updates iOS SDK to [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
+- Resolves [issue 754](https://github.com/plaid/react-native-plaid-link-sdk/issues/754)
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.1.0)
+
+#### Changes
+
+- Improved RememberMe experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.0.3 — 2025-02-04
+
+### React Native
+
+- Updates iOS SDK to [6.0.4](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.4)
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.4](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.4)
+
+#### Changes
+
+- Fixed an issue where some sessions experienced delays in receiving the LAYER_READY event or did not receive it at all.
+- Fixed an issue with XCFramework signature.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.0.2 — 2025-01-30
+
+### React Native
+
+- Fixed: Resolved an [issue](https://github.com/plaid/react-native-plaid-link-sdk/issues/747) where the USE_FRAMEWORKS preprocessor check was failing for projects using use_frameworks! :linkage => :static.
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.2)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+- Improved returning user experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.0.1 — 2025-01-24
+
+### React Native
+
+- Resolves issues with react native >= 0.76.0.
+- Remove deprecated PlaidLink component.
+- Remove deprecated openLink function.
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.2](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.2)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+- Improved returning user experience.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.0.0 — 2025-01-03
+
+### React Native
+
+- Remove deprecated PlaidLink component.
+- Remove deprecated openLink function.
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [5.0.0](https://github.com/plaid/plaid-link-android/releases/tag/v5.0.0)
+
+### Additions
+
+- Add AUTO_SUBMIT event name.
+- Add INVALID_UPDATE_USERNAME item error.
+
+### Changes
+
+- Upgrade Kotlin to 1.9.25.
+- Upgrade to target and compile SDK version 35.
+- Upgrade androidx.databinding:viewbinding library from 8.1.2 to 8.6.1.
+- Upgrade androidx.activity:activity library from 1.6.0 to 1.8.2.
+- Upgrade androidx.core:core-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.fragment:fragment-ktx library from 1.9.0 to 1.13.0.
+- Upgrade androidx.room:room-ktx library from 2.6.0 to 2.6.1.
+- Upgrade androidx.lifecycle:lifecycle-runtime-ktx library from 2.5.1 to 2.6.1.
+- Upgrade org.jetbrains.kotlinx:kotlinx-coroutines-core library from 1.7.1 to 1.7.3.
+
+### Removals
+
+- Remove PROFILE_ELIGIBILITY_CHECK_ERROR event name.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 16.1.0 |
+| iOS | >= 14.0 |
+
+
+
+## LinkKit V12.0.0-beta.3 — 2024-08-06
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [4.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.4.0)
+
+#### Changes
+- Support Autofill for SMS OTP in Link Sessions using Google play-services-auth-api-phone library version 18.0.2.
+- Change LinkActivity to `exported=false`.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.0-beta5](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0-beta5)
+
+#### Changes
+
+- Resolves bug where large transaction syncs failed.
+- Resolves bug where large account balance extraction failed.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.3.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.0.0-beta.2 — 2024-05-24
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [4.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.4.0)
+
+#### Changes
+- Support Autofill for SMS OTP in Link Sessions using Google play-services-auth-api-phone library version 18.0.2.
+- Change LinkActivity to `exported=false`.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.0-beta2](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0-beta2)
+
+#### Changes
+
+- Add Objective-C FinanceKit APIs for React Native.
+- Add support for FinanceKit and Apple card.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.3.0 |
+| iOS | >= 14.0 |
+
+
+## LinkKit V12.0.0-beta.1 — 2024-05-22
+
+### React Native
+
+#### Requirements
+
+This SDK now works with any supported version of React Native.
+
+### Android
+
+Android SDK [4.4.0](https://github.com/plaid/plaid-link-android/releases/tag/v4.4.0)
+
+#### Changes
+- Support Autofill for SMS OTP in Link Sessions using Google play-services-auth-api-phone library version 18.0.2.
+- Change LinkActivity to `exported=false`.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Android Studio | 4.0+ |
+| Kotlin | 1.8+ |
+
+### iOS
+
+iOS SDK [6.0.0-beta1](https://github.com/plaid/plaid-link-ios/releases/tag/6.0.0-beta1)
+
+#### Changes
+
+- Add support for FinanceKit and Apple card.
+
+#### Requirements
+
+| Name | Version |
+|------|---------|
+| Xcode | >= 15.3.0 |
+| iOS | >= 14.0 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+## 13.0.0 - 2026-06-26
+
+v13 is a major release that rebuilds the React Native SDK on Expo Modules,
+updates the native Link integrations to iOS LinkKit 7.0.0 and Android
+`sdk-core` 6.0.0, and introduces a session-based JavaScript API for Link flows.
+
+For detailed migration examples, see [V13_MIGRATION_GUIDE.md](./V13_MIGRATION_GUIDE.md).
+
+### Breaking Changes
+
+- Replaced the legacy global `create`, `open`, `submit`, `openLink`,
+  `PlaidLink`, and `usePlaidEmitter` APIs with explicit session objects:
+  `createPlaidLinkSession`, `createPlaidLayerSession`, and
+  `createPlaidHeadlessSession`.
+- Rebuilt the package as an Expo Module. Bare React Native apps must install and
+  configure Expo Modules before using v13.
+- Expo Go is not supported because Plaid Link requires custom native code. Expo
+  apps should use a development build or another custom native runtime.
+- Standard Link, Layer, and Headless callbacks are now registered per session
+  instead of through a shared event emitter.
+- `metadataJson` is the canonical callback metadata field. Update stale
+  `metadata_json` references from v11 or v12 TypeScript code.
+- Removed `errorDisplayMessage` from `LinkError`. Use `displayMessage` instead.
+- `syncFinanceKit` now returns a promise and remains iOS-only. Android calls
+  reject with an unsupported-platform error.
+- Renamed `LinkAccountSubtypeInvestment.SIIP` to
+  `LinkAccountSubtypeInvestment.SIPP`.
+
+### Native SDK Updates
+
+- Updated iOS to LinkKit 7.0.0, including the new session-based LinkKit API,
+  `PlaidLinkSession`, `PlaidLayerSession`, `PlaidHeadlessSession`,
+  first-class `onLoad` handling, native Embedded Search, and the modernized
+  FinanceKit sync API.
+- Updated Android to `com.plaid.link:sdk-core:6.0.0`, including the native
+  session APIs, Layer submit support, Headless Link support, and Embedded Search
+  continuation support.
+
+### New APIs
+
+- Added `createPlaidLinkSession({ token, onSuccess, onExit, onEvent, onLoad })`
+  for Standard Link.
+- Added `createPlaidLayerSession({ token, onSuccess, onExit, onEvent })` with
+  `session.open()` and `session.submit({ phoneNumber, dateOfBirth, params })`.
+- Added `createPlaidHeadlessSession({ token, onSuccess, onExit, onEvent })`
+  with `session.start()`.
+- Added `PlaidEmbeddedSearchView` for Embedded Search on iOS and Android.
+- Added promise-based `syncFinanceKit({ token, requestAuthorizationIfNeeded,
+  syncBehavior })` for iOS.
+
+### Package and Distribution
+
+- v13 publishes JavaScript and TypeScript entrypoints from `build/index.js` and
+  `build/index.d.ts`.
+- v13 ships the bundled iOS `LinkKit.xcframework` in the npm package because
+  LinkKit 7 no longer supports CocoaPods distribution. This intentionally
+  increases the npm tarball size compared with v12.
+- Excluded generated example projects, coverage output, and stale `dist` output
+  from the npm package.
+- Added package sanity checks to CI to verify entrypoints exist and are included
+  in the packed npm tarball.
+
+### Fixes
+
+- Aligned iOS fallback `onExit` payloads with the public React Native callback
+  contract by emitting `{ error, metadata }`.
+- Added callback contract tests to catch iOS, Android, or TypeScript payload
+  shape drift.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Plaid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,39 @@
-# react-native-plaid-link-sdk
+# Plaid React Native SDK
 
-React Native Plaid Link SDK (New Architecture & Expo)
+React Native SDK for Plaid Link, built on Expo Modules for the v13 native architecture.
 
-
-# API documentation
+## API documentation
 
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/react-native-plaid-link-sdk/)
 - [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/react-native-plaid-link-sdk/)
 
-# Migration guides
+## Migration guides
 
 - [v13 migration guide](./V13_MIGRATION_GUIDE.md)
 
-# Installation in managed Expo projects
+## Installation
 
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+### Expo projects
 
+Install the package and run the app in a development build or another custom native runtime. Expo Go cannot load custom native modules.
 
-# Installation in bare React Native projects
-
-For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-### Add the package to your npm dependencies
-
-```
+```sh
 npm install react-native-plaid-link-sdk
 ```
 
-### Configure for Android
+### Bare React Native projects
 
+Bare React Native apps must install and configure the [`expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before using this SDK.
 
+```sh
+npm install react-native-plaid-link-sdk
+npx pod-install
+```
 
+### Platform setup
 
-### Configure for iOS
+Configure Android package names, iOS bundle identifiers, and OAuth redirect settings in the Plaid Dashboard for the environments your app supports.
 
-Run `npx pod-install` after installing the npm package.
+## Contributing
 
-# Contributing
-
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Issues and pull requests are welcome in this repository.

--- a/ios/src/ReactNativePlaidLinkSdkModule.swift
+++ b/ios/src/ReactNativePlaidLinkSdkModule.swift
@@ -155,12 +155,13 @@ public class ReactNativePlaidLinkSdkModule: Module {
                 self.sendEvent(
                     ModuleEventName.onExit.rawValue,
                     [
-                        "displayMessage": errorMessage,
-                        "errorCode": errorCode,
-                        "errorType": "creation error",
-                        "errorMessage": errorMessage,
-                        "errorDisplayMessage": errorMessage,
-                        "errorJson": NSNull(),
+                        "error": [
+                            "displayMessage": errorMessage,
+                            "errorCode": errorCode,
+                            "errorType": "creation error",
+                            "errorMessage": errorMessage,
+                            "errorJson": NSNull(),
+                        ],
                         "metadata": [
                             "linkSessionId": NSNull(),
                             "institution": NSNull(),
@@ -210,12 +211,13 @@ public class ReactNativePlaidLinkSdkModule: Module {
                 self.sendEvent(
                     ModuleEventName.onExit.rawValue,
                     [
-                        "displayMessage": errorMessage,
-                        "errorCode": errorCode,
-                        "errorType": "creation error",
-                        "errorMessage": errorMessage,
-                        "errorDisplayMessage": errorMessage,
-                        "errorJson": NSNull(),
+                        "error": [
+                            "displayMessage": errorMessage,
+                            "errorCode": errorCode,
+                            "errorType": "creation error",
+                            "errorMessage": errorMessage,
+                            "errorJson": NSNull(),
+                        ],
                         "metadata": [
                             "linkSessionId": NSNull(),
                             "institution": NSNull(),
@@ -272,12 +274,13 @@ public class ReactNativePlaidLinkSdkModule: Module {
                 self.sendEvent(
                     ModuleEventName.onExit.rawValue,
                     [
-                        "displayMessage": errorMessage,
-                        "errorCode": errorCode,
-                        "errorType": "creation error",
-                        "errorMessage": errorMessage,
-                        "errorDisplayMessage": errorMessage,
-                        "errorJson": NSNull(),
+                        "error": [
+                            "displayMessage": errorMessage,
+                            "errorCode": errorCode,
+                            "errorType": "creation error",
+                            "errorMessage": errorMessage,
+                            "errorJson": NSNull(),
+                        ],
                         "metadata": [
                             "linkSessionId": NSNull(),
                             "institution": NSNull(),

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "expo-module build",
+    "check:package": "node scripts/check-package-entrypoints.js",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",

--- a/scripts/check-package-entrypoints.js
+++ b/scripts/check-package-entrypoints.js
@@ -1,10 +1,10 @@
-const { execFileSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
-const root = path.resolve(__dirname, '..');
-const packageJsonPath = path.join(root, 'package.json');
+const root = path.resolve(__dirname, "..");
+const packageJsonPath = path.join(root, "package.json");
 const packageJson = require(packageJsonPath);
 
 function fail(message) {
@@ -15,7 +15,7 @@ function fail(message) {
 function assertPackageFieldExists(fieldName) {
   const fieldValue = packageJson[fieldName];
 
-  if (typeof fieldValue !== 'string' || fieldValue.length === 0) {
+  if (typeof fieldValue !== "string" || fieldValue.length === 0) {
     fail(`package.json field "${fieldName}" must be a non-empty string.`);
   }
 
@@ -30,8 +30,63 @@ function assertPackageFieldExists(fieldName) {
   return fieldValue;
 }
 
-const main = assertPackageFieldExists('main');
-const types = assertPackageFieldExists('types');
+function parsePackJson(output) {
+  for (let start = 0; start < output.length; start += 1) {
+    if (output[start] !== "[") {
+      continue;
+    }
+
+    let depth = 0;
+    let inString = false;
+    let isEscaped = false;
+
+    for (let end = start; end < output.length; end += 1) {
+      const char = output[end];
+
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+
+      if (char === '"') {
+        inString = !inString;
+        continue;
+      }
+
+      if (inString) {
+        continue;
+      }
+
+      if (char === "[") {
+        depth += 1;
+      } else if (char === "]") {
+        depth -= 1;
+
+        if (depth === 0) {
+          const candidate = output.slice(start, end + 1);
+          try {
+            const parsed = JSON.parse(candidate);
+            if (Array.isArray(parsed)) {
+              return parsed;
+            }
+          } catch (_error) {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  fail("npm pack did not return a JSON array in its output.");
+}
+
+const main = assertPackageFieldExists("main");
+const types = assertPackageFieldExists("types");
 
 try {
   const resolved = require.resolve(root);
@@ -52,14 +107,14 @@ try {
 let packOutput;
 
 try {
-  packOutput = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+  packOutput = execFileSync("npm", ["pack", "--dry-run", "--json"], {
     cwd: root,
-    encoding: 'utf8',
+    encoding: "utf8",
     env: {
       ...process.env,
       npm_config_cache: path.join(
         os.tmpdir(),
-        'react-native-plaid-link-sdk-npm-cache',
+        "react-native-plaid-link-sdk-npm-cache",
       ),
     },
   });
@@ -67,20 +122,24 @@ try {
   fail(`npm pack --dry-run --json failed:\n${error.stderr || error.message}`);
 }
 
-let packResult;
-
-try {
-  packResult = JSON.parse(packOutput);
-} catch (error) {
-  fail(`npm pack did not return valid JSON: ${error.message}`);
-}
+const packResult = parsePackJson(packOutput);
 
 const packedFiles = (packResult[0] && packResult[0].files) || [];
-const files = new Set(packedFiles.map(file => file.path));
+const files = new Set(packedFiles.map((file) => file.path));
 
 for (const entrypoint of [main, types]) {
   if (!files.has(entrypoint)) {
     fail(`packed package does not include ${entrypoint}`);
+  }
+}
+
+for (const forbiddenPrefix of ["coverage/", "dist/", "example/"]) {
+  const forbiddenFile = packedFiles.find((file) =>
+    file.path.startsWith(forbiddenPrefix),
+  );
+
+  if (forbiddenFile) {
+    fail(`packed package must not include ${forbiddenFile.path}`);
   }
 }
 

--- a/src/__tests__/native-callback-contract.test.ts
+++ b/src/__tests__/native-callback-contract.test.ts
@@ -78,6 +78,33 @@ function extractCurlyBlock(source: string, marker: string): string {
   throw new Error(`Could not read block for ${marker}`);
 }
 
+function extractSwiftDictionaryAfter(source: string, marker: string): string {
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex === -1) {
+    throw new Error(`Could not find ${marker}`);
+  }
+
+  const start = source.indexOf("[", markerIndex);
+  if (start === -1) {
+    throw new Error(`Could not find dictionary for ${marker}`);
+  }
+
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "[") {
+      depth += 1;
+    } else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(start, index + 1);
+      }
+    }
+  }
+
+  throw new Error(`Could not read dictionary for ${marker}`);
+}
+
 function extractSwiftKeys(block: string, targetDepth: number): string[] {
   const keys = new Set<string>();
   let depth = 0;
@@ -177,6 +204,33 @@ describe("native callback payload contract", () => {
     expect(
       extractSwiftKeys(extractCurlyBlock(iosSource, "extension ExitError"), 1),
     ).toEqual(contract.error);
+  });
+
+  it("keeps iOS fallback exit dictionary keys aligned with the RN contract", () => {
+    const fallbackExitMessages = [
+      "createPlaidLinkSession was not called.",
+      "createPlaidLayerSession was not called.",
+      "createPlaidHeadlessSession was not called.",
+    ];
+
+    for (const message of fallbackExitMessages) {
+      const fallbackExit = extractSwiftDictionaryAfter(iosSource, message);
+
+      expect(fallbackExit).not.toContain("errorDisplayMessage");
+      expect(extractSwiftKeys(fallbackExit, 1)).toEqual(contract.exit);
+      expect(
+        extractSwiftKeys(
+          extractSwiftDictionaryAfter(fallbackExit, '"error"'),
+          1,
+        ),
+      ).toEqual(contract.error);
+      expect(
+        extractSwiftKeys(
+          extractSwiftDictionaryAfter(fallbackExit, '"metadata"'),
+          1,
+        ),
+      ).toEqual(contract.exitMetadata);
+    }
   });
 
   it("keeps Android callback mapper keys aligned with the RN contract", () => {


### PR DESCRIPTION
## Summary
- Excludes generated/local package artifacts while keeping v13 build output and native SDK files in the npm package.
- Adds CHANGELOG.md with v13.0.0 release notes and ports all V12.* entries from master, excluding V11/V10 history.
- Restores package sanity coverage with npm pack entrypoint checks in CI.
- Aligns iOS fallback onExit payloads with the RN callback contract and extends contract coverage.
- Restores the MIT license and trims stale README setup wording.

## Tarball comparison
- v13.0.0 local pack: 6,537,959 bytes (6.24 MiB) packed, 30,978,639 bytes (29.54 MiB) unpacked, 92 files.
- v12.8.3 npm pack: 110,797 bytes (108.20 KiB) packed, 379,660 bytes (370.76 KiB) unpacked, 102 files.
- v13 is larger primarily because it ships the bundled iOS LinkKit.xcframework.
- Confirmed v13 tarball includes build/** and excludes dist/**, coverage/**, and example/**.

## Validation
- npm run lint
- npm test -- --coverage --no-watch --passWithNoTests
- npm run build
- npm run check:package
- cd example && npx expo prebuild --platform android --clean
- cd example/android && ./gradlew testDebugUnitTest