### PR TITLE
Sync Android SDK version constant

### DIFF
--- a/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
@@ -1,0 +1,5 @@
+package expo.modules.plaidlinksdk
+
+internal object RNPlaidLinkSdkVersion {
+  const val SDK_VERSION = "13.0.0"
+}

--- a/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
@@ -28,7 +28,7 @@ class ReactNativePlaidLinkSdkModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ReactNativePlaidLinkSdk")
 
-    Constant("sdkVersion") { Plaid.VERSION_NAME }
+    Constant("sdkVersion") { RNPlaidLinkSdkVersion.SDK_VERSION }
 
     Events("PlaidLink.onSuccess", "PlaidLink.onExit", "PlaidLink.onEvent")
 

--- a/src/__tests__/swift-version-sync.test.ts
+++ b/src/__tests__/swift-version-sync.test.ts
@@ -53,3 +53,50 @@ describe("Swift Version Sync", () => {
     expect(swiftVersion).toMatch(semverRegex);
   });
 });
+
+describe("Android Version Sync", () => {
+  it("RNPlaidLinkSdkVersion.kt should match package.json version", () => {
+    const kotlinFilePath = path.join(
+      __dirname,
+      "../../android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt",
+    );
+    const kotlinContent = fs.readFileSync(kotlinFilePath, "utf-8");
+
+    const versionMatch = kotlinContent.match(/SDK_VERSION\s*=\s*"([^"]+)"/);
+
+    expect(versionMatch).not.toBeNull();
+
+    if (!versionMatch) {
+      fail(
+        "Could not find SDK_VERSION in RNPlaidLinkSdkVersion.kt. " +
+          'Expected format: const val SDK_VERSION = "X.X.X"',
+      );
+      return;
+    }
+
+    const kotlinVersion = versionMatch[1];
+    const packageVersion = packageJson.version;
+
+    expect(kotlinVersion).toBe(packageVersion);
+  });
+
+  it("Android version should be a valid semver string", () => {
+    const kotlinFilePath = path.join(
+      __dirname,
+      "../../android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt",
+    );
+    const kotlinContent = fs.readFileSync(kotlinFilePath, "utf-8");
+
+    const versionMatch = kotlinContent.match(/SDK_VERSION\s*=\s*"([^"]+)"/);
+
+    if (!versionMatch) {
+      fail("Could not find SDK_VERSION in Kotlin file");
+      return;
+    }
+
+    const kotlinVersion = versionMatch[1];
+    const semverRegex = /^\d+\.\d+\.\d+/;
+
+    expect(kotlinVersion).toMatch(semverRegex);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an Android RNPlaidLinkSdkVersion constant set to the React Native SDK package version.
- Updates the Android Expo module sdkVersion constant to return 13.0.0 instead of the native Android SDK version.
- Extends version sync tests so both iOS and Android constants must match package.json.

## Validation
- npm test -- --coverage --no-watch --passWithNoTests
- cd example/android && ./gradlew testDebugUnitTest