### PR TITLE
Prepare 13.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # RELEASES
 
+## LinkKit V13.0.1 — 2026-06-30
+
+### Changes
+
+- Fixes Expo SDK 56 iOS prebuild failures caused by the npm-packed
+  `LinkKit.xcframework` including an unsupported Mac Catalyst slice whose
+  framework symlinks were not preserved during packaging.
+- Ships an iOS-only `LinkKit.xcframework` with supported device and simulator
+  slices.
+- Adds package and CI validation for LinkKit XCFramework slices, signatures, and
+  Expo SDK 56 iOS prebuild compatibility.
+
 ## LinkKit V13.0.0 — 2026-06-26
 
 #### Requirements

--- a/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
@@ -1,5 +1,5 @@
 package expo.modules.plaidlinksdk
 
 internal object RNPlaidLinkSdkVersion {
-  const val SDK_VERSION = "13.0.0"
+  const val SDK_VERSION = "13.0.1"
 }

--- a/ios/src/RNPlaidLinkSdkVersion.swift
+++ b/ios/src/RNPlaidLinkSdkVersion.swift
@@ -15,5 +15,5 @@ public class RNPlaidLinkSdkVersion: NSObject {
     ///
     /// This should match the version specified in package.json.
     /// Update this value when bumping the SDK version.
-    @objc public static let sdkVersion: String = "13.0.0"
+    @objc public static let sdkVersion: String = "13.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "13.0.0",
+      "version": "13.0.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "React Native Plaid Link SDK (New Architecture & Expo)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
+++ b/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
@@ -5,7 +5,7 @@ const mockListeners: Record<string, Function[]> = {
 };
 
 const mockNativeModule = {
-  sdkVersion: "13.0.0",
+  sdkVersion: "13.0.1",
 
   createPlaidLinkSession: jest.fn(() => Promise.resolve()),
 


### PR DESCRIPTION
## LinkKit V13.0.1 — 2026-06-30

### Changes

- Fixes Expo SDK 56 iOS prebuild failures caused by the npm-packed
  `LinkKit.xcframework` including an unsupported Mac Catalyst slice whose
  framework symlinks were not preserved during packaging.
- Ships an iOS-only `LinkKit.xcframework` with supported device and simulator
  slices.
- Adds package and CI validation for LinkKit XCFramework slices, signatures, and
  Expo SDK 56 iOS prebuild compatibility.
