### PR TITLE
Restore Android React Native SDK metadata

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,7 @@
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <meta-data
+      android:name="com.plaid.link.react_native"
+      android:value="13.0.1" />
+  </application>
 </manifest>

--- a/src/__tests__/swift-version-sync.test.ts
+++ b/src/__tests__/swift-version-sync.test.ts
@@ -56,6 +56,11 @@ describe("Swift Version Sync", () => {
 });
 
 describe("Android Version Sync", () => {
+  const androidManifestPath = path.join(
+    __dirname,
+    "../../android/src/main/AndroidManifest.xml",
+  );
+
   it("RNPlaidLinkSdkVersion.kt should match package.json version", () => {
     const kotlinFilePath = path.join(
       __dirname,
@@ -99,5 +104,24 @@ describe("Android Version Sync", () => {
     const semverRegex = /^\d+\.\d+\.\d+/;
 
     expect(kotlinVersion).toMatch(semverRegex);
+  });
+
+  it("Android manifest should expose React Native wrapper metadata", () => {
+    const manifestContent = fs.readFileSync(androidManifestPath, "utf-8");
+
+    const metadataMatch = manifestContent.match(
+      /<meta-data\s+android:name="com\.plaid\.link\.react_native"\s+android:value="([^"]+)"\s*\/>/,
+    );
+
+    expect(metadataMatch).not.toBeNull();
+
+    if (!metadataMatch) {
+      fail(
+        "Could not find com.plaid.link.react_native metadata in AndroidManifest.xml.",
+      );
+      return;
+    }
+
+    expect(metadataMatch[1]).toBe(packageJson.version);
   });
 });


### PR DESCRIPTION
## Summary
- Restores the Android manifest metadata consumed by the native Android SDK to detect React Native wrapper usage.
- Adds a regression test to ensure the manifest metadata remains present and synced to package.json.

## Testing
- npm test -- --runInBand src/__tests__/swift-version-sync.test.ts --watchman=false
- npm run lint
- npm run check:package
- npm pack --pack-destination /private/tmp/rn-plaid-pack-verify --json --cache /private/tmp/react-native-plaid-link-sdk-npm-cache
- tar -xOf /private/tmp/rn-plaid-pack-verify/react-native-plaid-link-sdk-13.0.1.tgz package/android/src/main/AndroidManifest.xml