### PR TITLE
Document v13 removals missing from the changelog and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ code; Expo apps should use a development build or another custom native runtime.
   `createPlaidHeadlessSession`.
 - Removes the global `destroy` function. Each v13 flow is a discrete session
   object, so create a new session instead of clearing and reusing one.
+- Removes the iOS-only global `dismissLink` function; Link is dismissed when
+  the user completes or exits the flow.
+- Removes the `logLevel` and `noLoadingState` configuration options and the
+  `LinkLogLevel` enum. `noLoadingState` is superseded by
+  `createPlaidHeadlessSession`.
 - Adds `PlaidEmbeddedSearchView` for Embedded Search on iOS and Android.
 - Adds Headless Link support through `createPlaidHeadlessSession`.
 - Updates Layer to use `createPlaidLayerSession`, `session.open()`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ code; Expo apps should use a development build or another custom native runtime.
   `PlaidLink`, and `usePlaidEmitter` APIs with session objects:
   `createPlaidLinkSession`, `createPlaidLayerSession`, and
   `createPlaidHeadlessSession`.
+- Removes the global `destroy` function. Each v13 flow is a discrete session
+  object, so create a new session instead of clearing and reusing one.
 - Adds `PlaidEmbeddedSearchView` for Embedded Search on iOS and Android.
 - Adds Headless Link support through `createPlaidHeadlessSession`.
 - Updates Layer to use `createPlaidLayerSession`, `session.open()`, and

--- a/V13_MIGRATION_GUIDE.md
+++ b/V13_MIGRATION_GUIDE.md
@@ -467,6 +467,49 @@ await session.submit({ phoneNumber: "415-555-0015" });
 Action required: remove any calls to `destroy` and create a fresh session for
 each Link flow instead of clearing and reusing a previous one.
 
+### `dismissLink` removed
+
+The global `dismissLink` function has been removed. In v11 and v12 it
+programmatically dismissed the Link UI (iOS only; a no-op on Android). v13 has
+no equivalent — Link is dismissed when the user completes or exits the flow,
+which you observe through the `onSuccess` and `onExit` callbacks passed to the
+session.
+
+Action required: remove any calls to `dismissLink`.
+
+### `logLevel`, `LinkLogLevel`, and `noLoadingState` removed
+
+The `logLevel` and `noLoadingState` configuration options, and the
+`LinkLogLevel` enum, have been removed. A v13 session configuration is just a
+`token` plus the `onSuccess`, `onExit`, `onEvent`, and optional `onLoad`
+callbacks. `noLoadingState` is superseded by `createPlaidHeadlessSession`,
+which runs without SDK-provided UI.
+
+Before:
+
+```ts
+create({
+  token: "#GENERATED_LINK_TOKEN#",
+  logLevel: LinkLogLevel.ERROR,
+  noLoadingState: false,
+});
+```
+
+After:
+
+```ts
+const session = await createPlaidLinkSession({
+  token: "#GENERATED_LINK_TOKEN#",
+  onSuccess,
+  onExit,
+  onEvent,
+});
+```
+
+Action required: remove `logLevel`, `LinkLogLevel`, and `noLoadingState` from
+your configuration. If you used `noLoadingState` for a UI-less flow, use
+`createPlaidHeadlessSession` instead.
+
 ### `LinkAccountSubtypeInvestment.SIIP` renamed to `SIPP`
 
 The misspelled investment account subtype constant

--- a/V13_MIGRATION_GUIDE.md
+++ b/V13_MIGRATION_GUIDE.md
@@ -434,6 +434,39 @@ only available on iOS.
 
 ## Other Breaking Changes
 
+### `destroy` removed
+
+The global `destroy` function has been removed. In v11 and v12 it cleared
+native state from a previously opened session (Android only) and was mainly
+used with Layer when calling `create` more than once before `submit`. In v13
+each flow is a discrete session object returned by `createPlaidLinkSession`,
+`createPlaidLayerSession`, or `createPlaidHeadlessSession`, so there is no
+shared state to clear — create a new session instead of resetting a previous
+one.
+
+Before:
+
+```ts
+import { create, destroy, submit } from "react-native-plaid-link-sdk";
+
+create(tokenConfiguration1);
+await destroy(); // clear the previous session's state
+create(tokenConfiguration2);
+submit({ phoneNumber: "415-555-0015" });
+```
+
+After:
+
+```ts
+import { createPlaidLayerSession } from "react-native-plaid-link-sdk";
+
+const session = await createPlaidLayerSession(tokenConfiguration2);
+await session.submit({ phoneNumber: "415-555-0015" });
+```
+
+Action required: remove any calls to `destroy` and create a fresh session for
+each Link flow instead of clearing and reusing a previous one.
+
 ### `LinkAccountSubtypeInvestment.SIIP` renamed to `SIPP`
 
 The misspelled investment account subtype constant


### PR DESCRIPTION
Several v12 APIs were removed in v13 but weren't documented in the v13.0.0 changelog or the migration guide, so a v12 integration hits them with no callout. This adds them to both:

- `destroy` (global) — removed with no session replacement; create a new session per flow.
- `dismissLink` (iOS-only global) — removed with no equivalent; Link is dismissed when the user completes or exits the flow.
- `logLevel` / `LinkLogLevel` and `noLoadingState` — removed configuration options; `noLoadingState` is superseded by `createPlaidHeadlessSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)