### PR TITLE
Invoke onLoad for standard Link sessions

### DIFF
--- a/src/__tests__/createPlaidLinkSession.test.ts
+++ b/src/__tests__/createPlaidLinkSession.test.ts
@@ -237,6 +237,53 @@ describe("createPlaidLinkSession", () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
+  it("onLoad callback is invoked when provided", async () => {
+    const onLoadMock = jest.fn();
+    const config = {
+      token: "link-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+      onLoad: onLoadMock,
+    };
+
+    await createPlaidLinkSession(config);
+
+    expect(onLoadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onLoad is not provided", async () => {
+    const config = {
+      token: "link-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    };
+
+    await expect(createPlaidLinkSession(config)).resolves.toBeDefined();
+  });
+
+  it("does not invoke onLoad when native session creation fails", async () => {
+    const onLoadMock = jest.fn();
+    const mockError = new Error("Native session creation failed");
+    (
+      NativePlaidModule.createPlaidLinkSession as jest.Mock
+    ).mockRejectedValueOnce(mockError);
+
+    const config = {
+      token: "link-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+      onLoad: onLoadMock,
+    };
+
+    await expect(createPlaidLinkSession(config)).rejects.toThrow(
+      "Native session creation failed",
+    );
+    expect(onLoadMock).not.toHaveBeenCalled();
+  });
+
   it("handles errors during session creation and still returns session", async () => {
     const config = {
       token: "link-token",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ export async function createPlaidLinkSession(
 
   await NativePlaidModule.createPlaidLinkSession(config.token);
 
+  config.onLoad?.();
+
   return {
     open: (fullScreen = false) => NativePlaidModule.openLinkSession(fullScreen),
   };


### PR DESCRIPTION
## Summary
- Calls `config.onLoad?.()` after native Standard Link session creation resolves.
- Adds Standard Link tests covering onLoad success, absence, and native create failure behavior.

## Motivation
Native iOS and Android resolve `createPlaidLinkSession` when Link finishes loading, but the JS Standard Link wrapper did not invoke the documented `onLoad` callback. Headless already had this behavior; this brings Standard Link into parity with the documented API and native readiness signal.

## Testing
- `npm test -- --runInBand src/__tests__/createPlaidLinkSession.test.ts src/__tests__/createPlaidHeadlessSession.test.ts --watchman=false`
- `npm run lint`
