### PR TITLE
Fix v12 iOS Link callback cleanup

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,11 +1,12 @@
 name: Pull Request
 
 on:
-  # Triggers the workflow on a pull request pointed at master.
+  # Triggers the workflow on a pull request pointed at supported release branches.
   pull_request:
     branches:
       - "master"
-  
+      - "master-v12"
+
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Android SDK [5.5.3](https://github.com/plaid/plaid-link-android/releases/tag/v5.
 
 ### Changes
 
-- Upgrade to Android SDK [5.5.3](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.3).
+- Fix file uploads in Link. File picker, camera capture, and camera permission results now reach Link again, restoring document uploads (such as Document Income) that could silently fail since 3.9.0.
+- Report official Flutter wrapper metadata in SDK version details.
 
 ### iOS
 
@@ -28,7 +29,7 @@ iOS SDK [6.5.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.5.0)
 
 ### Changes
 
-- Upgrade to iOS SDK [6.5.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.5.0).
+- Fix FinanceKit Crash
 
 ## LinkKit V12.8.4 — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,24 @@ This SDK works with any supported version of React Native.
 - Harden iOS Link session cleanup for React Native New Architecture apps by clearing stored callbacks and releasing stale sessions before replacing them.
 - Add iOS support for `destroy()` so apps can dismiss Link and clear native callback state before starting a replacement session.
 - Enable the pull request workflow for PRs targeting `master-v12`.
+- Upgrade the Android SDK to version 5.5.3.
+- Upgrade the iOS SDK to LinkKit 6.5.0.
 
 ### Android
 
-Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+Android SDK [5.5.3](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.3)
 
 ### Changes
 
-- No underlying Android SDK upgrade.
+- Upgrade to Android SDK [5.5.3](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.3).
 
 ### iOS
 
-iOS SDK [6.4.7](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.7)
+iOS SDK [6.5.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.5.0)
 
 ### Changes
 
-- No underlying iOS SDK upgrade.
+- Upgrade to iOS SDK [6.5.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.5.0).
 
 ## LinkKit V12.8.4 — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # RELEASES
 
+## LinkKit V12.8.5 — 2026-07-31
+
+#### Requirements
+
+This SDK works with any supported version of React Native.
+
+### Changes
+
+- Harden iOS Link session cleanup for React Native New Architecture apps by clearing stored callbacks and releasing stale sessions before replacing them.
+- Add iOS support for `destroy()` so apps can dismiss Link and clear native callback state before starting a replacement session.
+- Enable the pull request workflow for PRs targeting `master-v12`.
+
+### Android
+
+Android SDK [5.5.2](https://github.com/plaid/plaid-link-android/releases/tag/v5.5.2)
+
+### Changes
+
+- No underlying Android SDK upgrade.
+
+### iOS
+
+iOS SDK [6.4.7](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.7)
+
+### Changes
+
+- No underlying iOS SDK upgrade.
+
 ## LinkKit V12.8.4 — 2026-07-20
 
 #### Requirements

--- a/FabricExample/Gemfile.lock
+++ b/FabricExample/Gemfile.lock
@@ -1,0 +1,122 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.9)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    claide (1.1.0)
+    cocoapods (1.15.2)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.15.2)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.2)
+      activesupport (>= 5.0, < 8)
+      addressable (~> 2.8)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix (~> 4.0)
+      typhoeus (~> 1.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (2.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.2.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.5.5)
+    drb (2.2.3)
+    escape (0.0.4)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
+    ffi (1.17.4)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    json (2.21.2)
+    logger (1.7.0)
+    minitest (5.26.1)
+    molinillo (0.8.0)
+    mutex_m (0.3.0)
+    nanaimo (0.3.0)
+    nap (1.1.0)
+    netrc (0.11.0)
+    public_suffix (4.0.7)
+    rexml (3.4.4)
+    ruby-macho (2.5.1)
+    securerandom (0.3.2)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.25.1)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.6, < 4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (>= 6.1.7.5, != 7.1.0)
+  benchmark
+  bigdecimal
+  cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  concurrent-ruby (< 1.3.4)
+  logger
+  mutex_m
+  xcodeproj (< 1.26.0)
+
+RUBY VERSION
+   ruby 2.7.8p225
+
+BUNDLED WITH
+   2.4.22

--- a/FabricExample/ios/Podfile
+++ b/FabricExample/ios/Podfile
@@ -31,5 +31,13 @@ target 'FabricExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'fmt'
+
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+      end
+    end
   end
 end

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - Plaid (6.4.2)
+  - Plaid (6.4.7)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1749,14 +1749,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-plaid-link-sdk (12.7.0):
+  - react-native-plaid-link-sdk (12.8.4):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - Plaid (~> 6.4.2)
+    - Plaid (~> 6.4.7)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2522,7 +2522,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  Plaid: 8a212ed955d480364e0deb7fed93625b29811e9d
+  Plaid: 2f4e0d6deb335e141ac62e082a872414ca058b74
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
@@ -2556,7 +2556,7 @@ SPEC CHECKSUMS:
   React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
   React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
   React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-plaid-link-sdk: f294b5737e57e6c5368bb293deeca5c0070f51ed
+  react-native-plaid-link-sdk: 99fb9f67cc9d915c8861638a839eddc7fa369cc0
   React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
   React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
@@ -2588,8 +2588,8 @@ SPEC CHECKSUMS:
   ReactCodegen: 4d203eddf6f977caa324640a20f92e70408d648b
   ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: fa23995c18b65978347b096d0836f4f5093df545
+  Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
 
-PODFILE CHECKSUM: 25c4a61a446ea222280eb1884fb8614b5e062b6e
+PODFILE CHECKSUM: 4920e234423c7af2f4fba8c720a5e18c4e3fd305
 
 COCOAPODS: 1.16.2

--- a/FabricExample/src/App.tsx
+++ b/FabricExample/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   SafeAreaView,
   ScrollView,
@@ -9,6 +9,9 @@ import {
   Alert,
   StyleSheet,
   TextInput,
+  NativeEventEmitter,
+  Platform,
+  TurboModuleRegistry,
 } from 'react-native';
 
 import { 
@@ -31,27 +34,34 @@ function isValidString(str: string): boolean {
 function createLinkTokenConfiguration(
   token: string,
   noLoadingState: boolean = false,
+  appendLog: (message: string, payload?: unknown) => void,
 ): LinkTokenConfiguration {
   console.log(`token: ${token}`);
+  appendLog('token', token);
   return {
     token,
     noLoadingState,
     onLoad: () => {
       console.log('Link onLoad: finished loading');
+      appendLog('Link onLoad: finished loading');
     },
   };
 }
 
-function createLinkOpenProps(): LinkOpenProps {
+function createLinkOpenProps(
+  appendLog: (message: string, payload?: unknown) => void,
+): LinkOpenProps {
   return {
     onSuccess: (success: LinkSuccess) => {
       Alert.alert('Success', `Link successful: ${JSON.stringify(success, null, 2)}`);
       console.log('Success: ', success);
+      appendLog('Success', success);
       success.metadata.accounts.forEach(account => console.log('accounts', account));
     },
     onExit: (linkExit: LinkExit) => {
       Alert.alert('Exit', `Link exited: ${JSON.stringify(linkExit, null, 2)}`);
       console.log('Exit: ', linkExit);
+      appendLog('Exit', linkExit);
     },
     iOSPresentationStyle: LinkIOSPresentationStyle.MODAL,
     logLevel: LinkLogLevel.ERROR,
@@ -62,13 +72,54 @@ function App(): React.JSX.Element {
   const [linkToken, setLinkToken] = useState('');
   const [disabled, setDisabled] = useState(true);
   const [currentScreen, setCurrentScreen] = useState('main');
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const appendLog = useCallback((message: string, payload?: unknown) => {
+    const timestamp = new Date().toLocaleTimeString();
+    const serializedPayload =
+      payload === undefined
+        ? ''
+        : ` ${typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2)}`;
+    const line = `[${timestamp}] ${message}${serializedPayload}`;
+    console.log(line);
+    setLogs(previousLogs => [line, ...previousLogs].slice(0, 30));
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
+    const plaidModule = TurboModuleRegistry.get('RNLinksdk');
+    if (!plaidModule) {
+      appendLog('Plaid event listener: RNLinksdk native module unavailable');
+      return;
+    }
+
+    appendLog('Plaid event listener: subscribed');
+    const emitter = new NativeEventEmitter(plaidModule as any);
+    const listener = emitter.addListener('onEvent', event => {
+      console.log('Event: ', event);
+      appendLog('Event', event);
+    });
+
+    return () => {
+      appendLog('Plaid event listener: unsubscribed');
+      listener.remove();
+    };
+  }, [appendLog]);
 
   const handleCreateLink = () => {
     try {
       if (isValidString(linkToken)) {
-        const tokenConfiguration = createLinkTokenConfiguration(linkToken);
+        const tokenConfiguration = createLinkTokenConfiguration(
+          linkToken,
+          false,
+          appendLog,
+        );
         create(tokenConfiguration);
         setDisabled(false);
+        appendLog('create() called');
         Alert.alert('Success', 'Link created successfully!');
       } else {
         Alert.alert('Error', 'Please enter a valid link token');
@@ -80,7 +131,8 @@ function App(): React.JSX.Element {
 
   const handleOpenLink = () => {
     try {
-      const openProps = createLinkOpenProps();
+      const openProps = createLinkOpenProps(appendLog);
+      appendLog('open() called');
       open(openProps);
       setDisabled(true);
     } catch (error) {
@@ -161,6 +213,24 @@ function App(): React.JSX.Element {
               </Text>
             </TouchableOpacity>
           </View>
+
+          <View style={styles.logContainer}>
+            <View style={styles.logHeader}>
+              <Text style={styles.logTitle}>Debug log</Text>
+              <TouchableOpacity onPress={() => setLogs([])}>
+                <Text style={styles.clearLogText}>Clear</Text>
+              </TouchableOpacity>
+            </View>
+            {logs.length === 0 ? (
+              <Text style={styles.emptyLogText}>No logs yet</Text>
+            ) : (
+              logs.map((line, index) => (
+                <Text key={`${line}-${index}`} style={styles.logLine}>
+                  {line}
+                </Text>
+              ))
+            )}
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -230,6 +300,39 @@ const styles = StyleSheet.create({
     color: '#ccddff',
     fontSize: 14,
     textAlign: 'center',
+  },
+  logContainer: {
+    borderColor: '#dddddd',
+    borderRadius: 8,
+    borderWidth: 1,
+    marginHorizontal: 20,
+    marginTop: 12,
+    padding: 12,
+  },
+  logHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  logTitle: {
+    color: '#222222',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  clearLogText: {
+    color: '#0066cc',
+    fontSize: 14,
+  },
+  emptyLogText: {
+    color: '#777777',
+    fontSize: 13,
+  },
+  logLine: {
+    color: '#222222',
+    fontFamily: Platform.select({ios: 'Courier', android: 'monospace'}),
+    fontSize: 11,
+    marginBottom: 6,
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
-| 12.8.5            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.7 |  14.0           | Active, supports Xcode 16.1.0 |
+| 12.8.5            | *                        | [5.5.3+]    | 21                  | 34                     | >=6.5.0 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.4            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.7 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.3            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.2            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The React Native Plaid module emits `onEvent` events throughout the account link
 
 #### Clearing Previous Session State with `destroy()`
 
-The `destroy()` method clears state and resources from a previously opened session.  
+The `destroy()` method clears state and resources from a previously opened session. On iOS, it also dismisses any presented Link UI and clears stored callback state.
 It's especially useful if you're seeing unexpected behavior when calling `create()` multiple times — for example, if the phone number isn't submitting properly after multiple `create()` calls.
 
 #### Problem scenario:
@@ -215,6 +215,7 @@ If migrating from older versions, see the [docs](https://plaid.com/docs/link/rea
 
 | Plaid SDK Version | Min React Native Version | Android SDK | Android Min Version | Android Compile Version| iOS SDK | iOS Min Version | Status                        |
 |-------------------|--------------------------|-------------|---------------------|------------------------|---------|-----------------|-------------------------------|
+| 12.8.5            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.7 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.4            | *                        | [5.5.2+]    | 21                  | 34                     | >=6.4.7 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.3            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |
 | 12.8.2            | *                        | [5.5.1+]    | 21                  | 34                     | >=6.4.3 |  14.0           | Active, supports Xcode 16.1.0 |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.plaid.link:sdk-core:5.5.2"
+    implementation "com.plaid.link:sdk-core:5.5.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="12.8.4" />
+      android:value="12.8.5" />
   </application>
 
 </manifest>

--- a/android/src/paper/java/com/plaid/NativePlaidLinkModuleiOSSpec.java
+++ b/android/src/paper/java/com/plaid/NativePlaidLinkModuleiOSSpec.java
@@ -14,6 +14,7 @@ package com.plaid;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -44,6 +45,10 @@ public abstract class NativePlaidLinkModuleiOSSpec extends ReactContextBaseJavaM
   @ReactMethod
   @DoNotStrip
   public abstract void dismiss();
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void destroy(Promise promise);
 
   @ReactMethod
   @DoNotStrip

--- a/ios/RNLinksdk.mm
+++ b/ios/RNLinksdk.mm
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import <LinkKit/LinkKit.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 
@@ -28,7 +29,7 @@ static NSString* const kRNLinkKitVersionConstant = @"version";
 RCT_EXPORT_MODULE();
 
 + (NSString*)sdkVersion {
-    return @"12.8.4"; // SDK_VERSION
+    return @"12.8.5"; // SDK_VERSION
 }
 
 + (NSString*)objCBridgeVersion {
@@ -67,16 +68,38 @@ RCT_EXPORT_MODULE();
     self.hasObservers = NO;
 }
 
+- (void)invalidate {
+    [self releaseCurrentSession];
+    [super invalidate];
+}
+
+- (void)dismissPresentedViewController {
+    [self.presentingViewController dismissViewControllerAnimated:YES
+                                                      completion:nil];
+    self.presentingViewController = nil;
+}
+
+- (void)releaseCurrentSession {
+    [self dismissPresentedViewController];
+    self.successCallback = nil;
+    self.exitCallback = nil;
+    self.linkHandler = nil;
+    self.creationError = nil;
+}
+
 RCT_EXPORT_METHOD(createPlaidLink:(NSString*)token noLoadingState:(BOOL)noLoadingState onLoad:(RCTResponseSenderBlock)onLoad) {
+    [self releaseCurrentSession];
+
     __weak RNLinksdk *weakSelf = self;
 
     void (^onSuccess)(PLKLinkSuccess *) = ^(PLKLinkSuccess *success) {
         RNLinksdk *strongSelf = weakSelf;
 
         if (strongSelf.successCallback) {
+            RCTResponseSenderBlock successCallback = strongSelf.successCallback;
             NSDictionary<NSString*, id> *jsMetadata = [RNLinksdk dictionaryFromSuccess:success];
-            strongSelf.successCallback(@[jsMetadata]);
-            strongSelf.successCallback = nil;
+            [strongSelf releaseCurrentSession];
+            successCallback(@[jsMetadata]);
         }
     };
 
@@ -84,14 +107,16 @@ RCT_EXPORT_METHOD(createPlaidLink:(NSString*)token noLoadingState:(BOOL)noLoadin
         RNLinksdk *strongSelf = weakSelf;
 
         if (strongSelf.exitCallback) {
+            RCTResponseSenderBlock exitCallback = strongSelf.exitCallback;
             NSDictionary *exitMetadata = [RNLinksdk dictionaryFromExit:exit];
+            NSArray *callbackArguments = nil;
             if (exit.error) {
-                strongSelf.exitCallback(@[exitMetadata[@"error"], exitMetadata]);
+                callbackArguments = @[exitMetadata[@"error"], exitMetadata];
             } else {
-                strongSelf.exitCallback(@[[NSNull null], exitMetadata]);
+                callbackArguments = @[[NSNull null], exitMetadata];
             }
-            strongSelf.exitCallback = nil;
-            strongSelf.linkHandler = nil;
+            [strongSelf releaseCurrentSession];
+            exitCallback(callbackArguments);
         }
     };
 
@@ -135,8 +160,14 @@ RCT_EXPORT_METHOD(createPlaidLink:(NSString*)token noLoadingState:(BOOL)noLoadin
 
 RCT_EXPORT_METHOD(open:(BOOL)fullScreen onSuccess:(RCTResponseSenderBlock)onSuccess onExit:(RCTResponseSenderBlock)onExit) {
     if (self.linkHandler) {
+        BOOL alreadyOpen = self.successCallback || self.exitCallback;
         self.successCallback = onSuccess;
         self.exitCallback = onExit;
+
+        if (alreadyOpen) {
+            return;
+        }
+
         self.presentingViewController = RCTPresentedViewController();
 
         // Some link flows do not need to present UI, so track if presentation happened so dismissal isn't
@@ -156,7 +187,7 @@ RCT_EXPORT_METHOD(open:(BOOL)fullScreen onSuccess:(RCTResponseSenderBlock)onSucc
         };
         void(^dismissalHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
             if (didPresent) {
-                [weakSelf dismiss];
+                [weakSelf dismissPresentedViewController];
                 didPresent = NO;
             }
         };
@@ -186,9 +217,12 @@ RCT_EXPORT_METHOD(open:(BOOL)fullScreen onSuccess:(RCTResponseSenderBlock)onSucc
 }
 
 RCT_EXPORT_METHOD(dismiss) {
-    [self.presentingViewController dismissViewControllerAnimated:YES
-                                                      completion:nil];
-    self.presentingViewController = nil;
+    [self releaseCurrentSession];
+}
+
+RCT_EXPORT_METHOD(destroy:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self releaseCurrentSession];
+    resolve(nil);
 }
 
 RCT_EXPORT_METHOD(syncFinanceKit:(NSString *)token

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.8.4",
+  "version": "12.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "12.8.4",
+      "version": "12.8.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "12.8.4",
+  "version": "12.8.5",
   "description": "React Native Plaid Link SDK",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/react-native-plaid-link-sdk.podspec
+++ b/react-native-plaid-link-sdk.podspec
@@ -36,5 +36,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'Plaid', '~> 6.4.7'
+  s.dependency 'Plaid', '~> 6.5.0'
 end

--- a/src/PlaidLink.tsx
+++ b/src/PlaidLink.tsx
@@ -106,6 +106,8 @@ export const open = (props: LinkOpenProps) => {
 export const destroy = async () => {
   if (Platform.OS === 'android') {
     await RNLinksdkAndroid?.destroy();
+  } else {
+    await RNLinksdkiOS?.destroy();
   }
 };
 

--- a/src/__tests__/iOSCallbackLifecycle.tests.js
+++ b/src/__tests__/iOSCallbackLifecycle.tests.js
@@ -1,0 +1,127 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '../..');
+const rnLinksdk = fs.readFileSync(path.join(root, 'ios/RNLinksdk.mm'), 'utf8');
+const plaidLink = fs.readFileSync(path.join(root, 'src/PlaidLink.tsx'), 'utf8');
+const iosSpec = fs.readFileSync(
+  path.join(root, 'src/fabric/NativePlaidLinkModuleiOS.ts'),
+  'utf8',
+);
+const iosJavaSpec = fs.readFileSync(
+  path.join(
+    root,
+    'android/src/paper/java/com/plaid/NativePlaidLinkModuleiOSSpec.java',
+  ),
+  'utf8',
+);
+
+const indexOfOrThrow = (source, needle) => {
+  const index = source.indexOf(needle);
+  if (index === -1) {
+    throw new Error(`Expected source to contain: ${needle}`);
+  }
+  return index;
+};
+
+describe('iOS callback lifecycle hardening', () => {
+  test('exposes destroy through the iOS JS and native specs', () => {
+    expect(plaidLink).toContain('await RNLinksdkiOS?.destroy();');
+    expect(iosSpec).toContain('destroy(): Promise<void>;');
+    expect(iosJavaSpec).toContain('import com.facebook.react.bridge.Promise;');
+    expect(iosJavaSpec).toContain(
+      'public abstract void destroy(Promise promise);',
+    );
+  });
+
+  test('releaseCurrentSession clears callbacks, handler, and creation error', () => {
+    const releaseStart = indexOfOrThrow(
+      rnLinksdk,
+      '- (void)releaseCurrentSession',
+    );
+    const createStart = indexOfOrThrow(
+      rnLinksdk,
+      'RCT_EXPORT_METHOD(createPlaidLink',
+    );
+    const releaseBody = rnLinksdk.slice(releaseStart, createStart);
+
+    expect(releaseBody).toContain('[self dismissPresentedViewController];');
+    expect(releaseBody).toContain('self.successCallback = nil;');
+    expect(releaseBody).toContain('self.exitCallback = nil;');
+    expect(releaseBody).toContain('self.linkHandler = nil;');
+    expect(releaseBody).toContain('self.creationError = nil;');
+  });
+
+  test('terminal callbacks release stored callback state before invoking JavaScript', () => {
+    const successCopy = indexOfOrThrow(
+      rnLinksdk,
+      'RCTResponseSenderBlock successCallback = strongSelf.successCallback;',
+    );
+    const successRelease = indexOfOrThrow(
+      rnLinksdk,
+      '[strongSelf releaseCurrentSession];\n            successCallback(@[jsMetadata]);',
+    );
+    const successInvoke = indexOfOrThrow(
+      rnLinksdk,
+      'successCallback(@[jsMetadata]);',
+    );
+
+    expect(successCopy).toBeLessThan(successRelease);
+    expect(successRelease).toBeLessThan(successInvoke);
+
+    const exitCopy = indexOfOrThrow(
+      rnLinksdk,
+      'RCTResponseSenderBlock exitCallback = strongSelf.exitCallback;',
+    );
+    const exitRelease = indexOfOrThrow(
+      rnLinksdk,
+      '[strongSelf releaseCurrentSession];\n            exitCallback(callbackArguments);',
+    );
+    const exitInvoke = indexOfOrThrow(
+      rnLinksdk,
+      'exitCallback(callbackArguments);',
+    );
+
+    expect(exitCopy).toBeLessThan(exitRelease);
+    expect(exitRelease).toBeLessThan(exitInvoke);
+  });
+
+  test('dismiss and destroy clear the session, while internal LinkKit dismissal only dismisses UI', () => {
+    expect(rnLinksdk).toMatch(
+      /RCT_EXPORT_METHOD\(dismiss\)\s*{\s*\[self releaseCurrentSession\];\s*}/,
+    );
+    expect(rnLinksdk).toContain(
+      'RCT_EXPORT_METHOD(destroy:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)',
+    );
+    expect(rnLinksdk).toContain(
+      '[self releaseCurrentSession];\n    resolve(nil);',
+    );
+    expect(rnLinksdk).toContain('[weakSelf dismissPresentedViewController];');
+    expect(rnLinksdk).not.toContain('[weakSelf dismiss];');
+  });
+
+  test('reentrant open updates callbacks without presenting LinkKit again', () => {
+    const alreadyOpen = indexOfOrThrow(
+      rnLinksdk,
+      'BOOL alreadyOpen = self.successCallback || self.exitCallback;',
+    );
+    const assignSuccess = indexOfOrThrow(
+      rnLinksdk,
+      'self.successCallback = onSuccess;',
+    );
+    const assignExit = indexOfOrThrow(rnLinksdk, 'self.exitCallback = onExit;');
+    const guard = indexOfOrThrow(
+      rnLinksdk,
+      'if (alreadyOpen) {\n            return;\n        }',
+    );
+    const openLink = indexOfOrThrow(
+      rnLinksdk,
+      '[self.linkHandler openWithPresentationHandler:presentationHandler dismissalHandler:dismissalHandler];',
+    );
+
+    expect(alreadyOpen).toBeLessThan(assignSuccess);
+    expect(assignSuccess).toBeLessThan(assignExit);
+    expect(assignExit).toBeLessThan(guard);
+    expect(guard).toBeLessThan(openLink);
+  });
+});

--- a/src/fabric/NativePlaidLinkModuleiOS.ts
+++ b/src/fabric/NativePlaidLinkModuleiOS.ts
@@ -13,6 +13,7 @@ export interface Spec extends TurboModule {
         onExit: (error: UnsafeObject<LinkError>, result: UnsafeObject<LinkExit>) => void,
       ): void;
     dismiss(): void;
+    destroy(): Promise<void>;
     submit(
       phoneNumber: string | undefined,
       dateOfBirth: string | undefined,


### PR DESCRIPTION
## Summary
- Prepare React Native SDK `12.8.5` for a v12 patch release.
- Harden iOS Link callback/session cleanup under React Native New Architecture by clearing stored callbacks and releasing stale sessions before replacing them.
- Add iOS support for `destroy()` so apps can dismiss Link and clear native callback state before starting another session.
- Upgrade Android Link SDK from `5.5.2` to `5.5.3`.
- Upgrade iOS LinkKit SDK from `6.4.7` to `6.5.0`.
- Add regression coverage for iOS callback lifecycle ordering and bridge exposure.

## Motivation
Customer reported hard iOS SIGABRT crashes on `react-native-plaid-link-sdk@12.7.0` after enabling React Native New Architecture. This mirrors the stale callback/session lifecycle issue fixed on Android in v12.8.4, but v12 iOS still retained one-shot callbacks after dismissal/replacement paths.