### PR TITLE
Limit Dependabot to SDK dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "example/**"


### PR DESCRIPTION
## Summary
- Adds a checked-in Dependabot config for npm updates at the SDK root.
- Excludes example app manifests via `exclude-paths: ["example/**"]` so Dependabot stops opening example-only dependency PRs.

## Context
Open Dependabot PRs show the noise is coming from `/example` package manifests, while root package updates still matter for the SDK.

## Testing
- Parsed `.github/dependabot.yml` with Ruby YAML parser.

## Notes
- Existing open example Dependabot PRs may need to be closed manually; this config should prevent new example-only Dependabot PRs after it lands on `master`.