### PR TITLE
Fix session callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ const session = await createPlaidHeadlessSession({
 await session.start();
 ```
 
+If a created session will no longer be opened, started, or submitted, call
+`await session.destroy()` to release it. Completed and exited sessions are
+released automatically.
+
 ## Embedded Search
 
 Embedded Search is available on iOS and Android through

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ await session.start();
 
 If a created session will no longer be opened, started, or submitted, call
 `await session.destroy()` to release it. Completed and exited sessions are
-released automatically.
+released automatically. Creating a new session also releases any previous
+session of the same kind that was never opened, started, or submitted;
+methods on a replaced session's handle will reject.
 
 ## Embedded Search
 

--- a/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
@@ -2,6 +2,8 @@ package expo.modules.plaidlinksdk
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import com.plaid.link.OnLoadCallback
 import com.plaid.link.Plaid
 import com.plaid.link.PlaidHeadlessSession
@@ -19,11 +21,13 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
 class ReactNativePlaidLinkSdkModule : Module() {
-  private var linkSession: PlaidLinkSession? = null
-  private var layerSession: PlaidLayerSession? = null
-  private var headlessSession: PlaidHeadlessSession? = null
-  private var activeSession: PlaidSession? = null
-  private var sessionCreationError: Throwable? = null
+  private val linkSessions = mutableMapOf<String, PlaidLinkSession>()
+  private val layerSessions = mutableMapOf<String, PlaidLayerSession>()
+  private val headlessSessions = mutableMapOf<String, PlaidHeadlessSession>()
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var activeSessionId: String? = null
+  private var postSuccessSessionId: String? = null
+  private var postSuccessCleanup: Runnable? = null
 
   override fun definition() = ModuleDefinition {
     Name("ReactNativePlaidLinkSdk")
@@ -31,6 +35,18 @@ class ReactNativePlaidLinkSdkModule : Module() {
     Constant("sdkVersion") { RNPlaidLinkSdkVersion.SDK_VERSION }
 
     Events("PlaidLink.onSuccess", "PlaidLink.onExit", "PlaidLink.onEvent")
+
+    OnCreate {
+      Plaid.setLinkEventListener { event ->
+        (activeSessionId ?: postSuccessSessionId)?.let { clientSessionId ->
+          sendSessionEvent("PlaidLink.onEvent", clientSessionId, event.toWritableMap())
+        }
+      }
+    }
+
+    OnDestroy {
+      clearAllSessions()
+    }
 
     View(ReactNativePlaidLinkSdkView::class) {
       Events("onSuccess", "onExit", "onEvent", "onLoad")
@@ -43,75 +59,76 @@ class ReactNativePlaidLinkSdkModule : Module() {
       }
     }
 
-    AsyncFunction("createPlaidLinkSession") { token: String, promise: Promise ->
+    AsyncFunction("createPlaidLinkSession") { clientSessionId: String, token: String, promise: Promise ->
       try {
+        clearPostSuccessSession()
         val activity = requireActivity()
-        Plaid.setLinkEventListener { event -> sendEvent("PlaidLink.onEvent", event.toWritableMap()) }
         val config = LinkTokenConfiguration.Builder()
           .token(token)
           .onLoad(OnLoadCallback { promise.resolve(null) })
           .build()
-        linkSession = Plaid.createPlaidLinkSession(activity, config)
-        activeSession = linkSession
-        sessionCreationError = null
+        linkSessions[clientSessionId] = Plaid.createPlaidLinkSession(activity, config)
       } catch (error: Throwable) {
-        sessionCreationError = error
+        clearSession(clientSessionId)
         promise.reject("LINK_SESSION_CREATE_ERROR", error.message ?: "Failed to create Link session", error)
       }
     }
 
-    AsyncFunction("createPlaidLayerSession") { token: String, promise: Promise ->
+    AsyncFunction("createPlaidLayerSession") { clientSessionId: String, token: String, promise: Promise ->
       try {
+        clearPostSuccessSession()
         val activity = requireActivity()
-        Plaid.setLinkEventListener { event -> sendEvent("PlaidLink.onEvent", event.toWritableMap()) }
         val config = LayerTokenConfiguration.Builder().token(token).build()
-        layerSession = Plaid.createPlaidLayerSession(activity, config)
-        activeSession = layerSession
-        sessionCreationError = null
+        layerSessions[clientSessionId] = Plaid.createPlaidLayerSession(activity, config)
         promise.resolve(null)
       } catch (error: Throwable) {
-        sessionCreationError = error
+        clearSession(clientSessionId)
         promise.reject("LAYER_SESSION_CREATE_ERROR", error.message ?: "Failed to create Layer session", error)
       }
     }
 
-    AsyncFunction("createPlaidHeadlessSession") { token: String, promise: Promise ->
+    AsyncFunction("createPlaidHeadlessSession") { clientSessionId: String, token: String, promise: Promise ->
       try {
+        clearPostSuccessSession()
         val activity = requireActivity()
-        Plaid.setLinkEventListener { event -> sendEvent("PlaidLink.onEvent", event.toWritableMap()) }
         val config = LinkTokenConfiguration.Builder()
           .token(token)
           .onLoad(OnLoadCallback { promise.resolve(null) })
           .build()
-        headlessSession = Plaid.createPlaidHeadlessSession(activity, config)
-        activeSession = headlessSession
-        sessionCreationError = null
+        headlessSessions[clientSessionId] = Plaid.createPlaidHeadlessSession(activity, config)
       } catch (error: Throwable) {
-        sessionCreationError = error
+        clearSession(clientSessionId)
         promise.reject("HEADLESS_SESSION_CREATE_ERROR", error.message ?: "Failed to create Headless session", error)
       }
     }
 
-    AsyncFunction("openLinkSession") { _: Boolean, promise: Promise ->
-      openSession(linkSession, "createPlaidLinkSession was not called.", promise)
+    AsyncFunction("openLinkSession") { clientSessionId: String, _: Boolean, promise: Promise ->
+      openSession(clientSessionId, linkSessions[clientSessionId], promise)
     }
 
-    AsyncFunction("openLayerSession") { promise: Promise ->
-      openSession(layerSession, "createPlaidLayerSession was not called.", promise)
+    AsyncFunction("openLayerSession") { clientSessionId: String, promise: Promise ->
+      openSession(clientSessionId, layerSessions[clientSessionId], promise)
     }
 
-    AsyncFunction("startHeadlessSession") { promise: Promise ->
-      openSession(headlessSession, "createPlaidHeadlessSession was not called.", promise)
+    AsyncFunction("startHeadlessSession") { clientSessionId: String, promise: Promise ->
+      openSession(clientSessionId, headlessSessions[clientSessionId], promise)
     }
 
-    AsyncFunction("submitLayerData") { phoneNumber: String?, dateOfBirth: String?, params: Map<String, String>?, promise: Promise ->
-      val session = layerSession
+    AsyncFunction("submitLayerData") { clientSessionId: String, phoneNumber: String?, dateOfBirth: String?, params: Map<String, String>?, promise: Promise ->
+      val session = layerSessions[clientSessionId]
       if (session == null) {
-        promise.reject("PLAID_NO_LAYER_SESSION", "Layer session not found. Call createPlaidLayerSession first.", null)
+        promise.reject("PLAID_NO_LAYER_SESSION", "Layer session not found for the supplied session identifier.", null)
+        return@AsyncFunction
+      }
+      if (!activateSession(clientSessionId, promise)) {
         return@AsyncFunction
       }
       session.submit(SubmissionData(phoneNumber = phoneNumber, dateOfBirth = dateOfBirth, params = params))
       promise.resolve(null)
+    }
+
+    AsyncFunction("destroySession") { clientSessionId: String ->
+      clearSession(clientSessionId)
     }
 
     AsyncFunction("syncFinanceKit") { _: String, _: Boolean, _: Int, promise: Promise ->
@@ -119,65 +136,114 @@ class ReactNativePlaidLinkSdkModule : Module() {
     }
   }
 
-  private fun openSession(session: PlaidSession?, missingSessionMessage: String, promise: Promise) {
+  private fun openSession(clientSessionId: String, session: PlaidSession?, promise: Promise) {
     if (session == null) {
-      sendCreationExit(missingSessionMessage)
-      promise.resolve(null)
+      promise.reject("PLAID_NO_SESSION", "Plaid session not found for the supplied session identifier.", null)
+      return
+    }
+    if (!activateSession(clientSessionId, promise)) {
       return
     }
 
     try {
       val activity = requireActivity()
-      activeSession = session
       session.open(activity)
       promise.resolve(null)
     } catch (error: Throwable) {
+      activeSessionId = null
       promise.reject("PLAID_OPEN_ERROR", error.message ?: "Failed to open Plaid session", error)
     }
+  }
+
+  private fun activateSession(clientSessionId: String, promise: Promise): Boolean {
+    val currentSessionId = activeSessionId
+    if (currentSessionId != null && currentSessionId != clientSessionId) {
+      promise.reject(
+        "PLAID_SESSION_ALREADY_ACTIVE",
+        "Another Plaid session is already active.",
+        null,
+      )
+      return false
+    }
+    if (postSuccessSessionId != clientSessionId) {
+      clearPostSuccessSession()
+    }
+    activeSessionId = clientSessionId
+    return true
   }
 
   private fun handleActivityResult(resultCode: Int, data: Intent?) {
     when (val result = Plaid.parseResult(Plaid.LINK_REQUEST_CODE, resultCode, data)) {
       is LinkSuccess -> {
         PlaidEmbeddedResultDispatcher.dispatch(result)
-        sendEvent("PlaidLink.onSuccess", result.toWritableMap())
-        clearActiveSession()
+        activeSessionId?.let { clientSessionId ->
+          sendSessionEvent("PlaidLink.onSuccess", clientSessionId, result.toWritableMap())
+          clearSession(clientSessionId)
+          retainPostSuccessSession(clientSessionId)
+        }
       }
       is LinkExit -> {
         PlaidEmbeddedResultDispatcher.dispatch(result)
-        sendEvent("PlaidLink.onExit", result.toWritableMap())
-        clearActiveSession()
+        activeSessionId?.let { clientSessionId ->
+          sendSessionEvent("PlaidLink.onExit", clientSessionId, result.toWritableMap())
+          clearSession(clientSessionId)
+        }
       }
       null -> Unit
     }
   }
 
-  private fun clearActiveSession() {
-    when (activeSession) {
-      linkSession -> linkSession = null
-      layerSession -> layerSession = null
-      headlessSession -> headlessSession = null
-    }
-    activeSession = null
-  }
-
-  private fun sendCreationExit(defaultMessage: String) {
-    val errorMessage = sessionCreationError?.localizedMessage ?: defaultMessage
+  private fun sendSessionEvent(eventName: String, clientSessionId: String, payload: Map<String, Any>) {
     sendEvent(
-      "PlaidLink.onExit",
+      eventName,
       mapOf(
-        "error" to mapOf(
-          "errorType" to "creation error",
-          "errorCode" to "-1",
-          "errorMessage" to errorMessage,
-          "displayMessage" to errorMessage,
-          "errorJson" to "",
-        ),
-        "metadata" to emptyExitMetadata(),
+        "clientSessionId" to clientSessionId,
+        "payload" to payload,
       ),
     )
   }
 
+  private fun clearSession(clientSessionId: String) {
+    linkSessions.remove(clientSessionId)
+    layerSessions.remove(clientSessionId)
+    headlessSessions.remove(clientSessionId)
+    if (activeSessionId == clientSessionId) {
+      activeSessionId = null
+    }
+    if (postSuccessSessionId == clientSessionId) {
+      clearPostSuccessSession()
+    }
+  }
+
+  private fun retainPostSuccessSession(clientSessionId: String) {
+    clearPostSuccessSession()
+    postSuccessSessionId = clientSessionId
+    postSuccessCleanup = Runnable {
+      if (postSuccessSessionId == clientSessionId) {
+        postSuccessSessionId = null
+        postSuccessCleanup = null
+      }
+    }.also { mainHandler.postDelayed(it, POST_SUCCESS_EVENT_WINDOW_MS) }
+  }
+
+  private fun clearPostSuccessSession() {
+    postSuccessCleanup?.let(mainHandler::removeCallbacks)
+    postSuccessCleanup = null
+    postSuccessSessionId = null
+  }
+
+  private fun clearAllSessions() {
+    linkSessions.clear()
+    layerSessions.clear()
+    headlessSessions.clear()
+    activeSessionId = null
+    clearPostSuccessSession()
+  }
+
   private fun requireActivity(): Activity = appContext.currentActivity
     ?: throw CodedException("Could not find current activity.")
+
+  companion object {
+    private const val POST_SUCCESS_EVENT_WINDOW_MS = 1500L
+  }
 }

--- a/ios/src/ReactNativePlaidLinkSdkModule.swift
+++ b/ios/src/ReactNativePlaidLinkSdkModule.swift
@@ -19,6 +19,10 @@ public class ReactNativePlaidLinkSdkModule: Module {
         // Defines event names that the module can send to JavaScript.
         Events(ModuleEventName.allCases.map { $0.rawValue })
 
+        OnDestroy {
+            self.clearAllSessions()
+        }
+
         // MARK: Views
 
         View(PlaidEmbeddedSearchView.self) {
@@ -31,18 +35,35 @@ public class ReactNativePlaidLinkSdkModule: Module {
 
         // MARK: Functions
 
-        AsyncFunction(ModuleFunctionName.createPlaidLinkSession.rawValue) { (token: String, onLoadPromise: Promise) in
+        AsyncFunction(ModuleFunctionName.createPlaidLinkSession.rawValue) {
+            (clientSessionId: String, token: String, onLoadPromise: Promise) in
             let onSuccess: OnSuccessHandler = { [weak self] success in
-                self?.sendEvent(ModuleEventName.onSuccess.rawValue, success.asDictionary)
+                self?.sendSessionEvent(
+                    ModuleEventName.onSuccess.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: success.asDictionary
+                )
+                self?.retainLinkSessionAfterSuccess(clientSessionId)
             }
 
             let onExit: OnExitHandler = { [weak self] exit in
-                self?.sendEvent(ModuleEventName.onExit.rawValue, exit.asDictionary)
-                self?.linkSession = nil
+                self?.sendSessionEvent(
+                    ModuleEventName.onExit.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: exit.asDictionary
+                )
+                self?.clearSession(clientSessionId)
             }
 
             let onEvent: OnEventHandler = { [weak self] event in
-                self?.sendEvent(ModuleEventName.onEvent.rawValue, event.asDictionary)
+                self?.sendSessionEvent(
+                    ModuleEventName.onEvent.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: event.asDictionary
+                )
+                if event.eventName == .handoff {
+                    self?.clearSession(clientSessionId)
+                }
             }
 
             let onLoad: OnLoadHandler = {
@@ -61,28 +82,41 @@ public class ReactNativePlaidLinkSdkModule: Module {
 
             do {
                 let session = try Plaid.createPlaidLinkSession(configuration: config)
-                self.linkSession = session
+                self.linkSessions[clientSessionId] = session
             } catch {
-                self.sessionCreationError = error
+                self.clearSession(clientSessionId)
                 DispatchQueue.main.async {
                     onLoadPromise.reject("LINK_SESSION_CREATE_ERROR", error.localizedDescription)
                 }
             }
         }
 
-        AsyncFunction(ModuleFunctionName.createPlaidLayerSession.rawValue) { (token: String, promise: Promise) in
+        AsyncFunction(ModuleFunctionName.createPlaidLayerSession.rawValue) {
+            (clientSessionId: String, token: String, promise: Promise) in
             let onSuccess: OnSuccessHandler = { [weak self] success in
-                self?.sendEvent(ModuleEventName.onSuccess.rawValue, success.asDictionary)
-                self?.layerSession = nil
+                self?.sendSessionEvent(
+                    ModuleEventName.onSuccess.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: success.asDictionary
+                )
+                self?.clearSession(clientSessionId)
             }
 
             let onExit: OnExitHandler = { [weak self] exit in
-                self?.sendEvent(ModuleEventName.onExit.rawValue, exit.asDictionary)
-                self?.layerSession = nil
+                self?.sendSessionEvent(
+                    ModuleEventName.onExit.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: exit.asDictionary
+                )
+                self?.clearSession(clientSessionId)
             }
 
             let onEvent: OnEventHandler = { [weak self] event in
-                self?.sendEvent(ModuleEventName.onEvent.rawValue, event.asDictionary)
+                self?.sendSessionEvent(
+                    ModuleEventName.onEvent.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: event.asDictionary
+                )
             }
 
             let config = LayerTokenConfiguration(
@@ -94,12 +128,12 @@ public class ReactNativePlaidLinkSdkModule: Module {
 
             do {
                 let session = try Plaid.createPlaidLayerSession(configuration: config)
-                self.layerSession = session
+                self.layerSessions[clientSessionId] = session
                 DispatchQueue.main.async {
                     promise.resolve()
                 }
             } catch {
-                self.sessionCreationError = error
+                self.clearSession(clientSessionId)
                 DispatchQueue.main.async {
                     promise.reject("LAYER_SESSION_CREATE_ERROR", error.localizedDescription)
                 }
@@ -107,19 +141,31 @@ public class ReactNativePlaidLinkSdkModule: Module {
         }
 
         AsyncFunction(ModuleFunctionName.createPlaidHeadlessSession.rawValue) {
-            (token: String, onLoadPromise: Promise) in
+            (clientSessionId: String, token: String, onLoadPromise: Promise) in
             let onSuccess: OnSuccessHandler = { [weak self] success in
-                self?.sendEvent(ModuleEventName.onSuccess.rawValue, success.asDictionary)
-                self?.headlessSession = nil
+                self?.sendSessionEvent(
+                    ModuleEventName.onSuccess.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: success.asDictionary
+                )
+                self?.clearSession(clientSessionId)
             }
 
             let onExit: OnExitHandler = { [weak self] exit in
-                self?.sendEvent(ModuleEventName.onExit.rawValue, exit.asDictionary)
-                self?.headlessSession = nil
+                self?.sendSessionEvent(
+                    ModuleEventName.onExit.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: exit.asDictionary
+                )
+                self?.clearSession(clientSessionId)
             }
 
             let onEvent: OnEventHandler = { [weak self] event in
-                self?.sendEvent(ModuleEventName.onEvent.rawValue, event.asDictionary)
+                self?.sendSessionEvent(
+                    ModuleEventName.onEvent.rawValue,
+                    clientSessionId: clientSessionId,
+                    payload: event.asDictionary
+                )
             }
 
             let onLoad: OnLoadHandler = {
@@ -138,49 +184,28 @@ public class ReactNativePlaidLinkSdkModule: Module {
 
             do {
                 let session = try Plaid.createHeadlessSession(configuration: config)
-                self.headlessSession = session
+                self.headlessSessions[clientSessionId] = session
             } catch {
-                self.sessionCreationError = error
+                self.clearSession(clientSessionId)
                 DispatchQueue.main.async {
                     onLoadPromise.reject("HEADLESS_SESSION_CREATE_ERROR", error.localizedDescription)
                 }
             }
         }
 
-        AsyncFunction(ModuleFunctionName.openLinkSession.rawValue) { (fullScreen: Bool, promise: Promise) in
-            guard let session = self.linkSession else {
-                let errorMessage =
-                    self.sessionCreationError?.localizedDescription ?? "createPlaidLinkSession was not called."
-                let errorCode = self.sessionCreationError.map { String($0._code) } ?? "-1"
-                self.sendEvent(
-                    ModuleEventName.onExit.rawValue,
-                    [
-                        "error": [
-                            "displayMessage": errorMessage,
-                            "errorCode": errorCode,
-                            "errorType": "creation error",
-                            "errorMessage": errorMessage,
-                            "errorJson": NSNull(),
-                        ],
-                        "metadata": [
-                            "linkSessionId": NSNull(),
-                            "institution": NSNull(),
-                            "status": NSNull(),
-                            "requestId": NSNull(),
-                            "metadataJson": NSNull(),
-                        ],
-                    ]
-                )
-
-                DispatchQueue.main.async {
-                    promise.resolve()  // not a failure to open, just a miscall
-                }
-
+        AsyncFunction(ModuleFunctionName.openLinkSession.rawValue) {
+            (clientSessionId: String, fullScreen: Bool, promise: Promise) in
+            guard let session = self.linkSessions[clientSessionId] else {
+                promise.reject("PLAID_NO_SESSION", "Plaid session not found for the supplied session identifier.")
                 return
             }
 
             DispatchQueue.main.async {
+                guard self.activateSession(clientSessionId, promise: promise) else {
+                    return
+                }
                 guard let vc = self.appContext?.utilities?.currentViewController() else {
+                    self.activeSessionId = nil
                     promise.reject("PLAID_NO_VC", "Could not find current view controller.")
                     return
                 }
@@ -203,40 +228,19 @@ public class ReactNativePlaidLinkSdkModule: Module {
             }
         }
 
-        AsyncFunction(ModuleFunctionName.openLayerSession.rawValue) { (promise: Promise) in
-            guard let layerSession = self.layerSession else {
-                let errorMessage =
-                    self.sessionCreationError?.localizedDescription ?? "createPlaidLayerSession was not called."
-                let errorCode = self.sessionCreationError.map { String($0._code) } ?? "-1"
-                self.sendEvent(
-                    ModuleEventName.onExit.rawValue,
-                    [
-                        "error": [
-                            "displayMessage": errorMessage,
-                            "errorCode": errorCode,
-                            "errorType": "creation error",
-                            "errorMessage": errorMessage,
-                            "errorJson": NSNull(),
-                        ],
-                        "metadata": [
-                            "linkSessionId": NSNull(),
-                            "institution": NSNull(),
-                            "status": NSNull(),
-                            "requestId": NSNull(),
-                            "metadataJson": NSNull(),
-                        ],
-                    ]
-                )
-
-                DispatchQueue.main.async {
-                    promise.resolve()
-                }
-
+        AsyncFunction(ModuleFunctionName.openLayerSession.rawValue) {
+            (clientSessionId: String, promise: Promise) in
+            guard let layerSession = self.layerSessions[clientSessionId] else {
+                promise.reject("PLAID_NO_LAYER_SESSION", "Layer session not found for the supplied session identifier.")
                 return
             }
 
             DispatchQueue.main.async {
+                guard self.activateSession(clientSessionId, promise: promise) else {
+                    return
+                }
                 guard let vc = self.appContext?.utilities?.currentViewController() else {
+                    self.activeSessionId = nil
                     promise.reject("PLAID_NO_VC", "Could not find current view controller.")
                     return
                 }
@@ -248,9 +252,9 @@ public class ReactNativePlaidLinkSdkModule: Module {
         }
 
         AsyncFunction(ModuleFunctionName.submitLayerData.rawValue) {
-            (phoneNumber: String?, dateOfBirth: String?, params: [String: String]?, promise: Promise) in
-            guard let layerSession = self.layerSession else {
-                promise.reject("PLAID_NO_LAYER_SESSION", "Layer session not found. Call createPlaidLayerSession first.")
+            (clientSessionId: String, phoneNumber: String?, dateOfBirth: String?, params: [String: String]?, promise: Promise) in
+            guard let layerSession = self.layerSessions[clientSessionId] else {
+                promise.reject("PLAID_NO_LAYER_SESSION", "Layer session not found for the supplied session identifier.")
                 return
             }
 
@@ -261,47 +265,32 @@ public class ReactNativePlaidLinkSdkModule: Module {
             )
 
             DispatchQueue.main.async {
+                guard self.activateSession(clientSessionId, promise: promise) else {
+                    return
+                }
                 layerSession.submit(data: submissionData)
                 promise.resolve()
             }
         }
 
-        AsyncFunction(ModuleFunctionName.startHeadlessSession.rawValue) { (promise: Promise) in
-            guard let headlessSession = self.headlessSession else {
-                let errorMessage =
-                    self.sessionCreationError?.localizedDescription ?? "createPlaidHeadlessSession was not called."
-                let errorCode = self.sessionCreationError.map { String($0._code) } ?? "-1"
-                self.sendEvent(
-                    ModuleEventName.onExit.rawValue,
-                    [
-                        "error": [
-                            "displayMessage": errorMessage,
-                            "errorCode": errorCode,
-                            "errorType": "creation error",
-                            "errorMessage": errorMessage,
-                            "errorJson": NSNull(),
-                        ],
-                        "metadata": [
-                            "linkSessionId": NSNull(),
-                            "institution": NSNull(),
-                            "status": NSNull(),
-                            "requestId": NSNull(),
-                            "metadataJson": NSNull(),
-                        ],
-                    ]
-                )
-
-                DispatchQueue.main.async {
-                    promise.resolve()
-                }
-
+        AsyncFunction(ModuleFunctionName.startHeadlessSession.rawValue) {
+            (clientSessionId: String, promise: Promise) in
+            guard let headlessSession = self.headlessSessions[clientSessionId] else {
+                promise.reject("PLAID_NO_SESSION", "Plaid session not found for the supplied session identifier.")
                 return
             }
 
             DispatchQueue.main.async {
+                guard self.activateSession(clientSessionId, promise: promise) else {
+                    return
+                }
                 headlessSession.start()
                 promise.resolve()
             }
+        }
+
+        AsyncFunction(ModuleFunctionName.destroySession.rawValue) { (clientSessionId: String) in
+            self.clearSession(clientSessionId)
         }
 
         AsyncFunction(ModuleFunctionName.syncFinanceKit.rawValue) {
@@ -354,15 +343,78 @@ public class ReactNativePlaidLinkSdkModule: Module {
         case openLayerSession
         case submitLayerData
         case startHeadlessSession
+        case destroySession
         case syncFinanceKit
     }
 
     // MARK: Private
 
-    private var linkSession: PlaidLinkSession?
-    private var layerSession: PlaidLayerSession?
-    private var headlessSession: PlaidHeadlessSession?
-    private var sessionCreationError: Error?
+    private var linkSessions: [String: PlaidLinkSession] = [:]
+    private var layerSessions: [String: PlaidLayerSession] = [:]
+    private var headlessSessions: [String: PlaidHeadlessSession] = [:]
+    private var postSuccessCleanupTasks: [String: DispatchWorkItem] = [:]
+    private var activeSessionId: String?
+
+    private func sendSessionEvent(
+        _ eventName: String,
+        clientSessionId: String,
+        payload: [String: Any]
+    ) {
+        sendEvent(
+            eventName,
+            [
+                "clientSessionId": clientSessionId,
+                "payload": payload,
+            ]
+        )
+    }
+
+    private func activateSession(_ clientSessionId: String, promise: Promise) -> Bool {
+        if let activeSessionId, activeSessionId != clientSessionId {
+            promise.reject("PLAID_SESSION_ALREADY_ACTIVE", "Another Plaid session is already active.")
+            return false
+        }
+        activeSessionId = clientSessionId
+        return true
+    }
+
+    private func clearSession(_ clientSessionId: String) {
+        postSuccessCleanupTasks.removeValue(forKey: clientSessionId)?.cancel()
+        linkSessions.removeValue(forKey: clientSessionId)
+        layerSessions.removeValue(forKey: clientSessionId)
+        headlessSessions.removeValue(forKey: clientSessionId)
+        if activeSessionId == clientSessionId {
+            activeSessionId = nil
+        }
+    }
+
+    private func retainLinkSessionAfterSuccess(_ clientSessionId: String) {
+        if activeSessionId == clientSessionId {
+            activeSessionId = nil
+        }
+        postSuccessCleanupTasks.removeValue(forKey: clientSessionId)?.cancel()
+
+        let cleanupTask = DispatchWorkItem { [weak self] in
+            self?.postSuccessCleanupTasks.removeValue(forKey: clientSessionId)
+            self?.linkSessions.removeValue(forKey: clientSessionId)
+        }
+        postSuccessCleanupTasks[clientSessionId] = cleanupTask
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.postSuccessEventWindow,
+            execute: cleanupTask
+        )
+    }
+
+    private func clearAllSessions() {
+        postSuccessCleanupTasks.values.forEach { $0.cancel() }
+        postSuccessCleanupTasks.removeAll()
+        linkSessions.removeAll()
+        layerSessions.removeAll()
+        headlessSessions.removeAll()
+        activeSessionId = nil
+    }
+
+    private static let postSuccessEventWindow: TimeInterval = 1.5
 }
 
 // MARK: Internal Extensions

--- a/src/ReactNativePlaidLinkSdk.types.ts
+++ b/src/ReactNativePlaidLinkSdk.types.ts
@@ -771,10 +771,15 @@ export enum LinkIOSPresentationStyle {
 }
 
 export type ReactNativePlaidLinkSdkModuleEvents = {
-  "PlaidLink.onSuccess": (success: LinkSuccess) => void;
-  "PlaidLink.onExit": (exit: LinkExit) => void;
-  "PlaidLink.onEvent": (event: LinkEvent) => void;
+  "PlaidLink.onSuccess": (event: NativeSessionEvent<LinkSuccess>) => void;
+  "PlaidLink.onExit": (event: NativeSessionEvent<LinkExit>) => void;
+  "PlaidLink.onEvent": (event: NativeSessionEvent<LinkEvent>) => void;
 };
+
+export interface NativeSessionEvent<T> {
+  clientSessionId: string;
+  payload: T;
+}
 
 export type LinkSuccessListener = (LinkSuccess: LinkSuccess) => void;
 export type LinkExitListener = (LinkExit: LinkExit) => void;
@@ -831,6 +836,7 @@ export interface EmbeddedLinkTokenConfiguration {
 
 export interface PlaidLinkSession {
   open: (fullScreen?: boolean) => Promise<void>;
+  destroy: () => Promise<void>;
 }
 
 export interface SubmissionData {
@@ -842,10 +848,12 @@ export interface SubmissionData {
 export interface PlaidLayerSession {
   open: () => Promise<void>;
   submit: (data: SubmissionData) => Promise<void>;
+  destroy: () => Promise<void>;
 }
 
 export interface PlaidHeadlessSession {
   start: () => Promise<void>;
+  destroy: () => Promise<void>;
 }
 
 export enum FinanceKitSyncBehavior {

--- a/src/ReactNativePlaidLinkSdkModule.ts
+++ b/src/ReactNativePlaidLinkSdkModule.ts
@@ -7,17 +7,25 @@ import {
 
 declare class ReactNativePlaidLinkSdkModule extends NativeModule<ReactNativePlaidLinkSdkModuleEvents> {
   sdkVersion: string;
-  createPlaidLinkSession(token: string): Promise<void>;
-  createPlaidLayerSession(token: string): Promise<void>;
-  createPlaidHeadlessSession(token: string): Promise<void>;
-  openLinkSession(fullScreen: boolean): Promise<void>;
-  openLayerSession(): Promise<void>;
-  startHeadlessSession(): Promise<void>;
+  createPlaidLinkSession(clientSessionId: string, token: string): Promise<void>;
+  createPlaidLayerSession(
+    clientSessionId: string,
+    token: string,
+  ): Promise<void>;
+  createPlaidHeadlessSession(
+    clientSessionId: string,
+    token: string,
+  ): Promise<void>;
+  openLinkSession(clientSessionId: string, fullScreen: boolean): Promise<void>;
+  openLayerSession(clientSessionId: string): Promise<void>;
+  startHeadlessSession(clientSessionId: string): Promise<void>;
   submitLayerData(
+    clientSessionId: string,
     phoneNumber?: string,
     dateOfBirth?: string,
     params?: Record<string, string>,
   ): Promise<void>;
+  destroySession(clientSessionId: string): Promise<void>;
   syncFinanceKit(
     token: string,
     requestAuthorizationIfNeeded: boolean,

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -12,6 +12,7 @@ type SessionConfiguration = LinkTokenConfiguration | LayerTokenConfiguration;
 interface SessionRecord {
   kind: SessionKind;
   config: SessionConfiguration;
+  activated: boolean;
   terminal: boolean;
   cleanupTimeout: ReturnType<typeof setTimeout> | null;
 }
@@ -103,6 +104,28 @@ function ensureNativeListeners() {
   });
 }
 
+// Creating a session replaces any prior session of the same kind that was
+// never activated (opened, started, or submitted). Activated sessions are
+// released by their terminal callbacks, and terminal sessions are kept until
+// the post-success handoff window closes.
+function evictReplacedSessions(kind: SessionKind, newClientSessionId: string) {
+  for (const [clientSessionId, record] of sessions) {
+    if (
+      clientSessionId === newClientSessionId ||
+      record.kind !== kind ||
+      record.activated ||
+      record.terminal
+    ) {
+      continue;
+    }
+
+    removeSession(clientSessionId);
+    NativePlaidModule.destroySession(clientSessionId).catch(() => {
+      // Native cleanup is best-effort; the JS record is already removed.
+    });
+  }
+}
+
 export function registerSession(
   kind: SessionKind,
   config: SessionConfiguration,
@@ -111,11 +134,23 @@ export function registerSession(
   sessions.set(clientSessionId, {
     kind,
     config,
+    activated: false,
     terminal: false,
     cleanupTimeout: null,
   });
+  evictReplacedSessions(kind, clientSessionId);
   ensureNativeListeners();
   return clientSessionId;
+}
+
+export function markSessionActivated(
+  clientSessionId: string,
+  activated: boolean,
+) {
+  const record = sessions.get(clientSessionId);
+  if (record) {
+    record.activated = activated;
+  }
 }
 
 export function removeSession(clientSessionId: string) {

--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -1,0 +1,145 @@
+import {
+  LayerTokenConfiguration,
+  LinkEventName,
+  LinkTokenConfiguration,
+} from "./ReactNativePlaidLinkSdk.types";
+import NativePlaidModule from "./ReactNativePlaidLinkSdkModule";
+
+type Subscription = ReturnType<typeof NativePlaidModule.addListener>;
+type SessionKind = "link" | "layer" | "headless";
+type SessionConfiguration = LinkTokenConfiguration | LayerTokenConfiguration;
+
+interface SessionRecord {
+  kind: SessionKind;
+  config: SessionConfiguration;
+  terminal: boolean;
+  cleanupTimeout: ReturnType<typeof setTimeout> | null;
+}
+
+const POST_SUCCESS_HANDOFF_EVENT_WINDOW_MS = 1500;
+const sessions = new Map<string, SessionRecord>();
+
+let nextSessionId = 0;
+let successSub: Subscription | null = null;
+let exitSub: Subscription | null = null;
+let eventSub: Subscription | null = null;
+
+function createClientSessionId(): string {
+  nextSessionId += 1;
+  return `plaid-session-${Date.now()}-${nextSessionId}`;
+}
+
+function clearNativeListeners() {
+  successSub?.remove();
+  exitSub?.remove();
+  eventSub?.remove();
+  successSub = null;
+  exitSub = null;
+  eventSub = null;
+}
+
+function ensureNativeListeners() {
+  if (successSub && exitSub && eventSub) {
+    return;
+  }
+
+  clearNativeListeners();
+  successSub = NativePlaidModule.addListener("PlaidLink.onSuccess", (event) => {
+    const record = sessions.get(event.clientSessionId);
+    if (!record || record.terminal) {
+      return;
+    }
+
+    if (record.kind === "link") {
+      record.terminal = true;
+      try {
+        record.config.onSuccess(event.payload);
+      } finally {
+        record.cleanupTimeout = setTimeout(() => {
+          removeSession(event.clientSessionId);
+        }, POST_SUCCESS_HANDOFF_EVENT_WINDOW_MS);
+        (record.cleanupTimeout as unknown as { unref?: () => void }).unref?.();
+      }
+      return;
+    }
+
+    try {
+      record.config.onSuccess(event.payload);
+    } finally {
+      removeSession(event.clientSessionId);
+    }
+  });
+
+  exitSub = NativePlaidModule.addListener("PlaidLink.onExit", (event) => {
+    const record = sessions.get(event.clientSessionId);
+    if (!record || record.terminal) {
+      return;
+    }
+
+    try {
+      record.config.onExit?.(event.payload);
+    } finally {
+      removeSession(event.clientSessionId);
+    }
+  });
+
+  eventSub = NativePlaidModule.addListener("PlaidLink.onEvent", (event) => {
+    const record = sessions.get(event.clientSessionId);
+    if (!record) {
+      return;
+    }
+
+    try {
+      record.config.onEvent?.(event.payload);
+    } finally {
+      if (
+        record.kind === "link" &&
+        record.terminal &&
+        event.payload.eventName === LinkEventName.HANDOFF
+      ) {
+        removeSession(event.clientSessionId);
+      }
+    }
+  });
+}
+
+export function registerSession(
+  kind: SessionKind,
+  config: SessionConfiguration,
+): string {
+  const clientSessionId = createClientSessionId();
+  sessions.set(clientSessionId, {
+    kind,
+    config,
+    terminal: false,
+    cleanupTimeout: null,
+  });
+  ensureNativeListeners();
+  return clientSessionId;
+}
+
+export function removeSession(clientSessionId: string) {
+  const record = sessions.get(clientSessionId);
+  if (!record) {
+    return;
+  }
+
+  if (record.cleanupTimeout) {
+    clearTimeout(record.cleanupTimeout);
+  }
+  sessions.delete(clientSessionId);
+
+  if (sessions.size === 0) {
+    clearNativeListeners();
+  }
+}
+
+export function resetSessionStateForTesting() {
+  for (const record of sessions.values()) {
+    if (record.cleanupTimeout) {
+      clearTimeout(record.cleanupTimeout);
+    }
+  }
+  sessions.clear();
+  clearNativeListeners();
+}

--- a/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
+++ b/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
@@ -3,26 +3,46 @@ const mockListeners: Record<string, Function[]> = {
   "PlaidLink.onExit": [],
   "PlaidLink.onEvent": [],
 };
+const mockCreatedSessionIds: string[] = [];
 
 const mockNativeModule = {
   sdkVersion: "13.0.4",
 
-  createPlaidLinkSession: jest.fn(() => Promise.resolve()),
+  createPlaidLinkSession: jest.fn((clientSessionId: string, token: string) => {
+    mockCreatedSessionIds.push(clientSessionId);
+    return Promise.resolve();
+  }),
 
-  createPlaidLayerSession: jest.fn(() => Promise.resolve()),
+  createPlaidLayerSession: jest.fn((clientSessionId: string, token: string) => {
+    mockCreatedSessionIds.push(clientSessionId);
+    return Promise.resolve();
+  }),
 
-  createPlaidHeadlessSession: jest.fn(() => Promise.resolve()),
+  createPlaidHeadlessSession: jest.fn(
+    (clientSessionId: string, token: string) => {
+      mockCreatedSessionIds.push(clientSessionId);
+      return Promise.resolve();
+    },
+  ),
 
-  openLinkSession: jest.fn((fullScreen: boolean) => Promise.resolve()),
+  openLinkSession: jest.fn((clientSessionId: string, fullScreen: boolean) =>
+    Promise.resolve(),
+  ),
 
-  openLayerSession: jest.fn(() => Promise.resolve()),
+  openLayerSession: jest.fn((clientSessionId: string) => Promise.resolve()),
 
-  startHeadlessSession: jest.fn(() => Promise.resolve()),
+  startHeadlessSession: jest.fn((clientSessionId: string) => Promise.resolve()),
 
   submitLayerData: jest.fn(
-    (phone?: string, dob?: string, params?: Record<string, string>) =>
-      Promise.resolve(),
+    (
+      clientSessionId: string,
+      phone?: string,
+      dob?: string,
+      params?: Record<string, string>,
+    ) => Promise.resolve(),
   ),
+
+  destroySession: jest.fn((clientSessionId: string) => Promise.resolve()),
 
   syncFinanceKit: jest.fn(
     (
@@ -48,16 +68,28 @@ const mockNativeModule = {
       };
     }),
 
-  __triggerEvent: (eventName: string, data: any) => {
+  __triggerEvent: (
+    eventName: string,
+    data: any,
+    clientSessionId = mockCreatedSessionIds[mockCreatedSessionIds.length - 1],
+  ) => {
     const listeners = mockListeners[eventName] || [];
-    listeners.forEach((callback) => callback(data));
+    listeners.forEach((callback) =>
+      callback({
+        clientSessionId,
+        payload: data,
+      }),
+    );
   },
 
   __clearListeners: () => {
     mockListeners["PlaidLink.onSuccess"] = [];
     mockListeners["PlaidLink.onExit"] = [];
     mockListeners["PlaidLink.onEvent"] = [];
+    mockCreatedSessionIds.length = 0;
   },
+
+  __getCreatedSessionIds: () => [...mockCreatedSessionIds],
 
   __getListenerCount: (eventName: string) => {
     return mockListeners[eventName]?.length || 0;

--- a/src/__tests__/createPlaidHeadlessSession.test.ts
+++ b/src/__tests__/createPlaidHeadlessSession.test.ts
@@ -5,10 +5,12 @@ import {
   LinkEventName,
 } from "../ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
 import { createPlaidHeadlessSession } from "../index";
 
 describe("createPlaidHeadlessSession", () => {
   beforeEach(() => {
+    resetSessionStateForTesting();
     jest.clearAllMocks();
     (NativePlaidModule as any).__clearListeners();
     (console.error as jest.Mock).mockClear();
@@ -26,6 +28,7 @@ describe("createPlaidHeadlessSession", () => {
     const session = await createPlaidHeadlessSession(config);
 
     expect(NativePlaidModule.createPlaidHeadlessSession).toHaveBeenCalledWith(
+      expect.any(String),
       "headless-token-123",
     );
     expect(session).toHaveProperty("start");
@@ -44,7 +47,9 @@ describe("createPlaidHeadlessSession", () => {
     const session = await createPlaidHeadlessSession(config);
 
     await session.start();
-    expect(NativePlaidModule.startHeadlessSession).toHaveBeenCalled();
+    expect(NativePlaidModule.startHeadlessSession).toHaveBeenCalledWith(
+      expect.any(String),
+    );
     expect(NativePlaidModule.startHeadlessSession).toHaveBeenCalledTimes(1);
     expect(console.log).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();
@@ -229,7 +234,7 @@ describe("createPlaidHeadlessSession", () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  it("cleans up existing listeners before creating new session", async () => {
+  it("shares native listeners without replacing session callbacks", async () => {
     const config1 = {
       token: "token-1",
       onSuccess: jest.fn(),
@@ -255,6 +260,6 @@ describe("createPlaidHeadlessSession", () => {
       .mock.calls.length;
 
     expect(firstListenerCalls).toBe(3);
-    expect(secondListenerCalls).toBe(3);
+    expect(secondListenerCalls).toBe(0);
   });
 });

--- a/src/__tests__/createPlaidLayerSession.test.ts
+++ b/src/__tests__/createPlaidLayerSession.test.ts
@@ -5,10 +5,12 @@ import {
   LinkEventName,
 } from "../ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
 import { createPlaidLayerSession } from "../index";
 
 describe("createPlaidLayerSession", () => {
   beforeEach(() => {
+    resetSessionStateForTesting();
     jest.clearAllMocks();
     (NativePlaidModule as any).__clearListeners();
     (console.error as jest.Mock).mockClear();
@@ -26,6 +28,7 @@ describe("createPlaidLayerSession", () => {
     const session = await createPlaidLayerSession(config);
 
     expect(NativePlaidModule.createPlaidLayerSession).toHaveBeenCalledWith(
+      expect.any(String),
       "layer-token-123",
     );
     expect(session).toHaveProperty("open");
@@ -94,6 +97,7 @@ describe("createPlaidLayerSession", () => {
 
     await session.submit({ phoneNumber: "555-1234" });
     expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
+      expect.any(String),
       "555-1234",
       undefined,
       undefined,
@@ -101,6 +105,7 @@ describe("createPlaidLayerSession", () => {
 
     await session.submit({ dateOfBirth: "1990-01-01" });
     expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
+      expect.any(String),
       undefined,
       "1990-01-01",
       undefined,
@@ -108,6 +113,7 @@ describe("createPlaidLayerSession", () => {
 
     await session.submit({ params: { foo: "bar", baz: "qux" } });
     expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
+      expect.any(String),
       undefined,
       undefined,
       { foo: "bar", baz: "qux" },
@@ -119,6 +125,7 @@ describe("createPlaidLayerSession", () => {
       params: { key: "value" },
     });
     expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
+      expect.any(String),
       "555-9999",
       "1985-12-25",
       { key: "value" },
@@ -167,7 +174,9 @@ describe("createPlaidLayerSession", () => {
     const session = await createPlaidLayerSession(config);
 
     await session.open();
-    expect(NativePlaidModule.openLayerSession).toHaveBeenCalled();
+    expect(NativePlaidModule.openLayerSession).toHaveBeenCalledWith(
+      expect.any(String),
+    );
     expect(NativePlaidModule.openLayerSession).toHaveBeenCalledTimes(1);
     expect(console.log).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();

--- a/src/__tests__/createPlaidLinkSession.test.ts
+++ b/src/__tests__/createPlaidLinkSession.test.ts
@@ -5,10 +5,12 @@ import {
   LinkEventName,
 } from "../ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
 import { createPlaidLinkSession } from "../index";
 
 describe("createPlaidLinkSession", () => {
   beforeEach(() => {
+    resetSessionStateForTesting();
     jest.clearAllMocks();
     (NativePlaidModule as any).__clearListeners();
     (console.error as jest.Mock).mockClear();
@@ -26,6 +28,7 @@ describe("createPlaidLinkSession", () => {
     const session = await createPlaidLinkSession(config);
 
     expect(NativePlaidModule.createPlaidLinkSession).toHaveBeenCalledWith(
+      expect.any(String),
       "link-sandbox-token-123",
     );
     expect(session).toHaveProperty("open");
@@ -45,7 +48,7 @@ describe("createPlaidLinkSession", () => {
     );
   });
 
-  it("cleans up existing listeners before creating new session", async () => {
+  it("shares native listeners without replacing session callbacks", async () => {
     const config1 = {
       token: "token-1",
       onSuccess: jest.fn(),
@@ -71,7 +74,7 @@ describe("createPlaidLinkSession", () => {
       .mock.calls.length;
 
     expect(firstListenerCalls).toBe(3);
-    expect(secondListenerCalls).toBe(3);
+    expect(secondListenerCalls).toBe(0);
   });
 
   it("returns session with working open method", async () => {
@@ -85,13 +88,22 @@ describe("createPlaidLinkSession", () => {
     const session = await createPlaidLinkSession(config);
 
     await session.open(true);
-    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(true);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      expect.any(String),
+      true,
+    );
 
     await session.open(false);
-    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(false);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      expect.any(String),
+      false,
+    );
 
     await session.open();
-    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(false);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      expect.any(String),
+      false,
+    );
     expect(console.log).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();
   });
@@ -309,6 +321,9 @@ describe("createPlaidLinkSession", () => {
     const session = await createPlaidLinkSession(config);
     await session.open();
 
-    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(false);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      expect.any(String),
+      false,
+    );
   });
 });

--- a/src/__tests__/listener-lifecycle.test.ts
+++ b/src/__tests__/listener-lifecycle.test.ts
@@ -5,10 +5,12 @@ import {
   LinkEventName,
 } from "../ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
 import { createPlaidLinkSession, createPlaidLayerSession } from "../index";
 
 describe("Listener Lifecycle", () => {
   beforeEach(() => {
+    resetSessionStateForTesting();
     jest.clearAllMocks();
     (NativePlaidModule as any).__clearListeners();
     (console.error as jest.Mock).mockClear();
@@ -56,10 +58,10 @@ describe("Listener Lifecycle", () => {
 
     expect(
       (NativePlaidModule as any).__getListenerCount("PlaidLink.onSuccess"),
-    ).toBe(0);
+    ).toBeGreaterThan(0);
     expect(
       (NativePlaidModule as any).__getListenerCount("PlaidLink.onExit"),
-    ).toBe(0);
+    ).toBeGreaterThan(0);
     expect(
       (NativePlaidModule as any).__getListenerCount("PlaidLink.onEvent"),
     ).toBeGreaterThan(0);
@@ -312,7 +314,7 @@ describe("Listener Lifecycle", () => {
     ).toBe(0);
   });
 
-  it("new session creation cancels pending post-success handoff cleanup", async () => {
+  it("an older handoff timeout does not remove a newer session", async () => {
     jest.useFakeTimers();
 
     const firstEvent = jest.fn();

--- a/src/__tests__/native-callback-contract.test.ts
+++ b/src/__tests__/native-callback-contract.test.ts
@@ -78,33 +78,6 @@ function extractCurlyBlock(source: string, marker: string): string {
   throw new Error(`Could not read block for ${marker}`);
 }
 
-function extractSwiftDictionaryAfter(source: string, marker: string): string {
-  const markerIndex = source.indexOf(marker);
-  if (markerIndex === -1) {
-    throw new Error(`Could not find ${marker}`);
-  }
-
-  const start = source.indexOf("[", markerIndex);
-  if (start === -1) {
-    throw new Error(`Could not find dictionary for ${marker}`);
-  }
-
-  let depth = 0;
-  for (let index = start; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === "[") {
-      depth += 1;
-    } else if (char === "]") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(start, index + 1);
-      }
-    }
-  }
-
-  throw new Error(`Could not read dictionary for ${marker}`);
-}
-
 function extractSwiftKeys(block: string, targetDepth: number): string[] {
   const keys = new Set<string>();
   let depth = 0;
@@ -175,6 +148,9 @@ describe("native callback payload contract", () => {
   const androidSource = readRepoFile(
     "android/src/main/java/expo/modules/plaidlinksdk/PlaidResultMappers.kt",
   );
+  const androidModuleSource = readRepoFile(
+    "android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt",
+  );
 
   it("keeps iOS callback dictionary keys aligned with the RN contract", () => {
     const success = extractCurlyBlock(iosSource, "extension LinkSuccess");
@@ -206,31 +182,33 @@ describe("native callback payload contract", () => {
     ).toEqual(contract.error);
   });
 
-  it("keeps iOS fallback exit dictionary keys aligned with the RN contract", () => {
-    const fallbackExitMessages = [
-      "createPlaidLinkSession was not called.",
-      "createPlaidLayerSession was not called.",
-      "createPlaidHeadlessSession was not called.",
-    ];
+  it("keys native session storage, operations, and callback envelopes by session identifier", () => {
+    expect(iosSource).toContain(
+      "private var linkSessions: [String: PlaidLinkSession]",
+    );
+    expect(iosSource).toContain(
+      "private var layerSessions: [String: PlaidLayerSession]",
+    );
+    expect(iosSource).toContain("self.linkSessions[clientSessionId]");
+    expect(iosSource).toContain("self.layerSessions[clientSessionId]");
+    expect(iosSource).toContain('"clientSessionId": clientSessionId');
+    expect(iosSource).toContain('"payload": payload');
+    expect(iosSource).toContain("clearSession(clientSessionId)");
 
-    for (const message of fallbackExitMessages) {
-      const fallbackExit = extractSwiftDictionaryAfter(iosSource, message);
-
-      expect(fallbackExit).not.toContain("errorDisplayMessage");
-      expect(extractSwiftKeys(fallbackExit, 1)).toEqual(contract.exit);
-      expect(
-        extractSwiftKeys(
-          extractSwiftDictionaryAfter(fallbackExit, '"error"'),
-          1,
-        ),
-      ).toEqual(contract.error);
-      expect(
-        extractSwiftKeys(
-          extractSwiftDictionaryAfter(fallbackExit, '"metadata"'),
-          1,
-        ),
-      ).toEqual(contract.exitMetadata);
-    }
+    expect(androidModuleSource).toContain(
+      "private val linkSessions = mutableMapOf<String, PlaidLinkSession>()",
+    );
+    expect(androidModuleSource).toContain(
+      "private val layerSessions = mutableMapOf<String, PlaidLayerSession>()",
+    );
+    expect(androidModuleSource).toContain("linkSessions[clientSessionId]");
+    expect(androidModuleSource).toContain("layerSessions[clientSessionId]");
+    expect(androidModuleSource).toContain(
+      '"clientSessionId" to clientSessionId',
+    );
+    expect(androidModuleSource).toContain('"payload" to payload');
+    expect(androidModuleSource).toContain("clearSession(clientSessionId)");
+    expect(androidModuleSource).toContain("PLAID_SESSION_ALREADY_ACTIVE");
   });
 
   it("keeps Android callback mapper keys aligned with the RN contract", () => {

--- a/src/__tests__/session-eviction.test.ts
+++ b/src/__tests__/session-eviction.test.ts
@@ -1,0 +1,175 @@
+import { LinkEventName } from "../ReactNativePlaidLinkSdk.types";
+import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
+import { createPlaidLayerSession, createPlaidLinkSession } from "../index";
+
+function createdSessionIds(): string[] {
+  return (NativePlaidModule as any).__getCreatedSessionIds();
+}
+
+function successFor(linkSessionId: string, publicToken: string) {
+  return {
+    publicToken,
+    metadata: {
+      accounts: [],
+      linkSessionId,
+    },
+  };
+}
+
+describe("session eviction on create", () => {
+  beforeEach(() => {
+    resetSessionStateForTesting();
+    jest.clearAllMocks();
+    (NativePlaidModule as any).__clearListeners();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("evicts a never-activated session of the same kind when a new one is created", async () => {
+    const onSuccessA = jest.fn();
+
+    await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: onSuccessA,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId] = createdSessionIds();
+    expect(NativePlaidModule.destroySession).toHaveBeenCalledWith(sessionAId);
+
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successFor("native-session-a", "public-token-a"),
+      sessionAId,
+    );
+    expect(onSuccessA).not.toHaveBeenCalled();
+  });
+
+  it("keeps an opened session when a new one of the same kind is created", async () => {
+    const onSuccessA = jest.fn();
+
+    const sessionA = await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: onSuccessA,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await sessionA.open();
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId] = createdSessionIds();
+    expect(NativePlaidModule.destroySession).not.toHaveBeenCalled();
+
+    const successA = successFor("native-session-a", "public-token-a");
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successA,
+      sessionAId,
+    );
+    expect(onSuccessA).toHaveBeenCalledWith(successA);
+  });
+
+  it("does not evict a pending session of a different kind", async () => {
+    await createPlaidLinkSession({
+      token: "link-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLayerSession({
+      token: "layer-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    expect(NativePlaidModule.destroySession).not.toHaveBeenCalled();
+  });
+
+  it("makes a session evictable again when its open call fails", async () => {
+    (NativePlaidModule.openLinkSession as jest.Mock).mockRejectedValueOnce(
+      new Error("PLAID_SESSION_ALREADY_ACTIVE"),
+    );
+
+    const sessionA = await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await expect(sessionA.open()).rejects.toThrow(
+      "PLAID_SESSION_ALREADY_ACTIVE",
+    );
+
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId] = createdSessionIds();
+    expect(NativePlaidModule.destroySession).toHaveBeenCalledWith(sessionAId);
+  });
+
+  it("keeps a post-success session draining for handoff when a new one is created", async () => {
+    jest.useFakeTimers();
+
+    const onEventA = jest.fn();
+
+    const sessionA = await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: onEventA,
+    });
+    await sessionA.open();
+
+    const [sessionAId] = createdSessionIds();
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successFor("native-session-a", "public-token-a"),
+      sessionAId,
+    );
+
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    expect(NativePlaidModule.destroySession).not.toHaveBeenCalled();
+
+    const handoffEvent = {
+      eventName: LinkEventName.HANDOFF,
+      metadata: {
+        linkSessionId: "native-session-a",
+        viewName: "CONNECTED" as any,
+        timestamp: "2026-03-27T12:00:00Z",
+        metadataJson: "{}",
+      },
+    };
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onEvent",
+      handoffEvent,
+      sessionAId,
+    );
+    expect(onEventA).toHaveBeenCalledWith(handoffEvent);
+  });
+});

--- a/src/__tests__/session-isolation.test.ts
+++ b/src/__tests__/session-isolation.test.ts
@@ -1,0 +1,238 @@
+import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { resetSessionStateForTesting } from "../SessionManager";
+import { createPlaidLayerSession, createPlaidLinkSession } from "../index";
+
+function createdSessionIds(): string[] {
+  return (NativePlaidModule as any).__getCreatedSessionIds();
+}
+
+function successFor(linkSessionId: string, publicToken: string) {
+  return {
+    publicToken,
+    metadata: {
+      accounts: [],
+      linkSessionId,
+    },
+  };
+}
+
+describe("session isolation", () => {
+  beforeEach(() => {
+    resetSessionStateForTesting();
+    jest.clearAllMocks();
+    (NativePlaidModule as any).__clearListeners();
+  });
+
+  it("routes an older session result only to the callback that created it", async () => {
+    const onSuccessA = jest.fn();
+    const onSuccessB = jest.fn();
+
+    await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: onSuccessA,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: onSuccessB,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionA] = createdSessionIds();
+    const successA = successFor("native-session-a", "public-token-a");
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successA,
+      sessionA,
+    );
+
+    expect(onSuccessA).toHaveBeenCalledWith(successA);
+    expect(onSuccessB).not.toHaveBeenCalled();
+  });
+
+  it("does not route callbacks across Link and Layer session types", async () => {
+    const linkSuccess = jest.fn();
+    const layerSuccess = jest.fn();
+
+    await createPlaidLinkSession({
+      token: "link-token",
+      onSuccess: linkSuccess,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLayerSession({
+      token: "layer-token",
+      onSuccess: layerSuccess,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [linkSessionId, layerSessionId] = createdSessionIds();
+    const linkResult = successFor("native-link-session", "link-public-token");
+    const layerResult = successFor(
+      "native-layer-session",
+      "layer-public-token",
+    );
+
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      linkResult,
+      linkSessionId,
+    );
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      layerResult,
+      layerSessionId,
+    );
+
+    expect(linkSuccess).toHaveBeenCalledWith(linkResult);
+    expect(linkSuccess).not.toHaveBeenCalledWith(layerResult);
+    expect(layerSuccess).toHaveBeenCalledWith(layerResult);
+    expect(layerSuccess).not.toHaveBeenCalledWith(linkResult);
+  });
+
+  it("binds a retained Link session open method to its original session", async () => {
+    const sessionA = await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId, sessionBId] = createdSessionIds();
+    await sessionA.open(true);
+
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      sessionAId,
+      true,
+    );
+    expect(NativePlaidModule.openLinkSession).not.toHaveBeenCalledWith(
+      sessionBId,
+      true,
+    );
+  });
+
+  it("binds retained Layer submission data to its original session", async () => {
+    const sessionA = await createPlaidLayerSession({
+      token: "layer-token-a",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLayerSession({
+      token: "layer-token-b",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId, sessionBId] = createdSessionIds();
+    await sessionA.submit({
+      phoneNumber: "415-555-0100",
+      dateOfBirth: "1975-01-18",
+    });
+
+    expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
+      sessionAId,
+      "415-555-0100",
+      "1975-01-18",
+      undefined,
+    );
+    expect(NativePlaidModule.submitLayerData).not.toHaveBeenCalledWith(
+      sessionBId,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("cleans up only the session that receives a terminal callback", async () => {
+    const onExitA = jest.fn();
+    const onSuccessB = jest.fn();
+
+    await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: jest.fn(),
+      onExit: onExitA,
+      onEvent: jest.fn(),
+    });
+    const sessionB = await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: onSuccessB,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId, sessionBId] = createdSessionIds();
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onExit",
+      { metadata: { linkSessionId: "native-session-a" } },
+      sessionAId,
+    );
+    await sessionB.open();
+    const successB = successFor("native-session-b", "public-token-b");
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successB,
+      sessionBId,
+    );
+
+    expect(onExitA).toHaveBeenCalledTimes(1);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
+      sessionBId,
+      false,
+    );
+    expect(onSuccessB).toHaveBeenCalledWith(successB);
+  });
+
+  it("drops events for destroyed and unknown session identifiers", async () => {
+    const onSuccessA = jest.fn();
+    const onSuccessB = jest.fn();
+
+    const sessionA = await createPlaidLinkSession({
+      token: "token-a",
+      onSuccess: onSuccessA,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+    await createPlaidLinkSession({
+      token: "token-b",
+      onSuccess: onSuccessB,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const [sessionAId, sessionBId] = createdSessionIds();
+    await sessionA.destroy();
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successFor("native-session-a", "public-token-a"),
+      sessionAId,
+    );
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successFor("unknown", "unknown-token"),
+      "unknown-session-id",
+    );
+
+    const successB = successFor("native-session-b", "public-token-b");
+    (NativePlaidModule as any).__triggerEvent(
+      "PlaidLink.onSuccess",
+      successB,
+      sessionBId,
+    );
+
+    expect(NativePlaidModule.destroySession).toHaveBeenCalledWith(sessionAId);
+    expect(onSuccessA).not.toHaveBeenCalled();
+    expect(onSuccessB).toHaveBeenCalledTimes(1);
+    expect(onSuccessB).toHaveBeenCalledWith(successB);
+  });
+});

--- a/src/__tests__/session-isolation.test.ts
+++ b/src/__tests__/session-isolation.test.ts
@@ -27,12 +27,13 @@ describe("session isolation", () => {
     const onSuccessA = jest.fn();
     const onSuccessB = jest.fn();
 
-    await createPlaidLinkSession({
+    const sessionA = await createPlaidLinkSession({
       token: "token-a",
       onSuccess: onSuccessA,
       onExit: jest.fn(),
       onEvent: jest.fn(),
     });
+    await sessionA.open();
     await createPlaidLinkSession({
       token: "token-b",
       onSuccess: onSuccessB,
@@ -40,12 +41,12 @@ describe("session isolation", () => {
       onEvent: jest.fn(),
     });
 
-    const [sessionA] = createdSessionIds();
+    const [sessionAId] = createdSessionIds();
     const successA = successFor("native-session-a", "public-token-a");
     (NativePlaidModule as any).__triggerEvent(
       "PlaidLink.onSuccess",
       successA,
-      sessionA,
+      sessionAId,
     );
 
     expect(onSuccessA).toHaveBeenCalledWith(successA);
@@ -100,6 +101,7 @@ describe("session isolation", () => {
       onExit: jest.fn(),
       onEvent: jest.fn(),
     });
+    await sessionA.open(true);
     await createPlaidLinkSession({
       token: "token-b",
       onSuccess: jest.fn(),
@@ -108,7 +110,6 @@ describe("session isolation", () => {
     });
 
     const [sessionAId, sessionBId] = createdSessionIds();
-    await sessionA.open(true);
 
     expect(NativePlaidModule.openLinkSession).toHaveBeenCalledWith(
       sessionAId,
@@ -127,6 +128,10 @@ describe("session isolation", () => {
       onExit: jest.fn(),
       onEvent: jest.fn(),
     });
+    await sessionA.submit({
+      phoneNumber: "415-555-0100",
+      dateOfBirth: "1975-01-18",
+    });
     await createPlaidLayerSession({
       token: "layer-token-b",
       onSuccess: jest.fn(),
@@ -135,10 +140,6 @@ describe("session isolation", () => {
     });
 
     const [sessionAId, sessionBId] = createdSessionIds();
-    await sessionA.submit({
-      phoneNumber: "415-555-0100",
-      dateOfBirth: "1975-01-18",
-    });
 
     expect(NativePlaidModule.submitLayerData).toHaveBeenCalledWith(
       sessionAId,
@@ -158,12 +159,13 @@ describe("session isolation", () => {
     const onExitA = jest.fn();
     const onSuccessB = jest.fn();
 
-    await createPlaidLinkSession({
+    const sessionA = await createPlaidLinkSession({
       token: "token-a",
       onSuccess: jest.fn(),
       onExit: onExitA,
       onEvent: jest.fn(),
     });
+    await sessionA.open();
     const sessionB = await createPlaidLinkSession({
       token: "token-b",
       onSuccess: onSuccessB,
@@ -203,6 +205,7 @@ describe("session isolation", () => {
       onExit: jest.fn(),
       onEvent: jest.fn(),
     });
+    await sessionA.open();
     await createPlaidLinkSession({
       token: "token-b",
       onSuccess: onSuccessB,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,6 @@
 import { Platform } from "react-native";
 
 import {
-  LinkExit,
-  LinkEvent,
-  LinkEventName,
-  LinkSuccess,
   LinkTokenConfiguration,
   PlaidLinkSession,
   LayerTokenConfiguration,
@@ -14,166 +10,90 @@ import {
   FinanceKitSyncBehavior,
 } from "./ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "./ReactNativePlaidLinkSdkModule";
+import { registerSession, removeSession } from "./SessionManager";
 
-type Subscription = ReturnType<typeof NativePlaidModule.addListener>;
-
-let successSub: Subscription | null = null;
-let exitSub: Subscription | null = null;
-let eventSub: Subscription | null = null;
-let postSuccessHandoffCleanupTimeout: ReturnType<typeof setTimeout> | null =
-  null;
-
-const POST_SUCCESS_HANDOFF_EVENT_WINDOW_MS = 1500;
-
-function clearPostSuccessHandoffCleanupTimeout() {
-  if (postSuccessHandoffCleanupTimeout) {
-    clearTimeout(postSuccessHandoffCleanupTimeout);
-    postSuccessHandoffCleanupTimeout = null;
+async function destroySession(clientSessionId: string): Promise<void> {
+  try {
+    await NativePlaidModule.destroySession(clientSessionId);
+  } finally {
+    removeSession(clientSessionId);
   }
-}
-
-function cleanupListeners(options: { keepEventListener?: boolean } = {}) {
-  clearPostSuccessHandoffCleanupTimeout();
-  successSub?.remove();
-  exitSub?.remove();
-  if (!options.keepEventListener) {
-    eventSub?.remove();
-    eventSub = null;
-  }
-  successSub = null;
-  exitSub = null;
-}
-
-function cleanupAfterPostSuccessHandoffWindow() {
-  postSuccessHandoffCleanupTimeout = setTimeout(() => {
-    cleanupListeners();
-  }, POST_SUCCESS_HANDOFF_EVENT_WINDOW_MS);
-  (
-    postSuccessHandoffCleanupTimeout as unknown as { unref?: () => void }
-  ).unref?.();
 }
 
 export async function createPlaidLinkSession(
   config: LinkTokenConfiguration,
 ): Promise<PlaidLinkSession> {
-  cleanupListeners();
+  const clientSessionId = registerSession("link", config);
 
-  successSub = NativePlaidModule.addListener(
-    "PlaidLink.onSuccess",
-    (success: LinkSuccess) => {
-      config.onSuccess(success);
-      cleanupListeners({ keepEventListener: true });
-      cleanupAfterPostSuccessHandoffWindow();
-    },
-  );
-
-  exitSub = NativePlaidModule.addListener(
-    "PlaidLink.onExit",
-    (exit: LinkExit) => {
-      config.onExit(exit);
-      cleanupListeners();
-    },
-  );
-
-  eventSub = NativePlaidModule.addListener(
-    "PlaidLink.onEvent",
-    (event: LinkEvent) => {
-      config.onEvent(event);
-      if (
-        postSuccessHandoffCleanupTimeout &&
-        event.eventName === LinkEventName.HANDOFF
-      ) {
-        cleanupListeners();
-      }
-    },
-  );
-
-  await NativePlaidModule.createPlaidLinkSession(config.token);
+  try {
+    await NativePlaidModule.createPlaidLinkSession(
+      clientSessionId,
+      config.token,
+    );
+  } catch (error) {
+    removeSession(clientSessionId);
+    throw error;
+  }
 
   config.onLoad?.();
 
   return {
-    open: (fullScreen = false) => NativePlaidModule.openLinkSession(fullScreen),
+    open: (fullScreen = false) =>
+      NativePlaidModule.openLinkSession(clientSessionId, fullScreen),
+    destroy: () => destroySession(clientSessionId),
   };
 }
 
 export async function createPlaidLayerSession(
   config: LayerTokenConfiguration,
 ): Promise<PlaidLayerSession> {
-  cleanupListeners();
+  const clientSessionId = registerSession("layer", config);
 
-  successSub = NativePlaidModule.addListener(
-    "PlaidLink.onSuccess",
-    (success: LinkSuccess) => {
-      config.onSuccess(success);
-      cleanupListeners();
-    },
-  );
-
-  exitSub = NativePlaidModule.addListener(
-    "PlaidLink.onExit",
-    (exit: LinkExit) => {
-      config.onExit?.(exit);
-      cleanupListeners();
-    },
-  );
-
-  eventSub = NativePlaidModule.addListener(
-    "PlaidLink.onEvent",
-    (event: LinkEvent) => {
-      config.onEvent?.(event);
-    },
-  );
-
-  await NativePlaidModule.createPlaidLayerSession(config.token);
+  try {
+    await NativePlaidModule.createPlaidLayerSession(
+      clientSessionId,
+      config.token,
+    );
+  } catch (error) {
+    removeSession(clientSessionId);
+    throw error;
+  }
 
   return {
-    open: () => NativePlaidModule.openLayerSession(),
+    open: () => NativePlaidModule.openLayerSession(clientSessionId),
     submit: (data: SubmissionData) =>
       NativePlaidModule.submitLayerData(
+        clientSessionId,
         data.phoneNumber,
         data.dateOfBirth,
         data.params,
       ),
+    destroy: () => destroySession(clientSessionId),
   };
 }
 
 export async function createPlaidHeadlessSession(
   config: LinkTokenConfiguration,
 ): Promise<PlaidHeadlessSession> {
-  cleanupListeners();
+  const clientSessionId = registerSession("headless", config);
 
-  successSub = NativePlaidModule.addListener(
-    "PlaidLink.onSuccess",
-    (success: LinkSuccess) => {
-      config.onSuccess(success);
-      cleanupListeners();
-    },
-  );
-
-  exitSub = NativePlaidModule.addListener(
-    "PlaidLink.onExit",
-    (exit: LinkExit) => {
-      config.onExit(exit);
-      cleanupListeners();
-    },
-  );
-
-  eventSub = NativePlaidModule.addListener(
-    "PlaidLink.onEvent",
-    (event: LinkEvent) => {
-      config.onEvent(event);
-    },
-  );
-
-  await NativePlaidModule.createPlaidHeadlessSession(config.token);
+  try {
+    await NativePlaidModule.createPlaidHeadlessSession(
+      clientSessionId,
+      config.token,
+    );
+  } catch (error) {
+    removeSession(clientSessionId);
+    throw error;
+  }
 
   if (config.onLoad) {
     config.onLoad();
   }
 
   return {
-    start: () => NativePlaidModule.startHeadlessSession(),
+    start: () => NativePlaidModule.startHeadlessSession(clientSessionId),
+    destroy: () => destroySession(clientSessionId),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,33 @@ import {
   FinanceKitSyncBehavior,
 } from "./ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "./ReactNativePlaidLinkSdkModule";
-import { registerSession, removeSession } from "./SessionManager";
+import {
+  markSessionActivated,
+  registerSession,
+  removeSession,
+} from "./SessionManager";
 
 async function destroySession(clientSessionId: string): Promise<void> {
   try {
     await NativePlaidModule.destroySession(clientSessionId);
   } finally {
     removeSession(clientSessionId);
+  }
+}
+
+// Activation is marked before the native call so an in-flight open cannot be
+// evicted by a concurrent create, and reverted on failure so the session
+// becomes replaceable again.
+async function activateSession(
+  clientSessionId: string,
+  action: () => Promise<void>,
+): Promise<void> {
+  markSessionActivated(clientSessionId, true);
+  try {
+    await action();
+  } catch (error) {
+    markSessionActivated(clientSessionId, false);
+    throw error;
   }
 }
 
@@ -39,7 +59,9 @@ export async function createPlaidLinkSession(
 
   return {
     open: (fullScreen = false) =>
-      NativePlaidModule.openLinkSession(clientSessionId, fullScreen),
+      activateSession(clientSessionId, () =>
+        NativePlaidModule.openLinkSession(clientSessionId, fullScreen),
+      ),
     destroy: () => destroySession(clientSessionId),
   };
 }
@@ -60,13 +82,18 @@ export async function createPlaidLayerSession(
   }
 
   return {
-    open: () => NativePlaidModule.openLayerSession(clientSessionId),
+    open: () =>
+      activateSession(clientSessionId, () =>
+        NativePlaidModule.openLayerSession(clientSessionId),
+      ),
     submit: (data: SubmissionData) =>
-      NativePlaidModule.submitLayerData(
-        clientSessionId,
-        data.phoneNumber,
-        data.dateOfBirth,
-        data.params,
+      activateSession(clientSessionId, () =>
+        NativePlaidModule.submitLayerData(
+          clientSessionId,
+          data.phoneNumber,
+          data.dateOfBirth,
+          data.params,
+        ),
       ),
     destroy: () => destroySession(clientSessionId),
   };
@@ -92,7 +119,10 @@ export async function createPlaidHeadlessSession(
   }
 
   return {
-    start: () => NativePlaidModule.startHeadlessSession(clientSessionId),
+    start: () =>
+      activateSession(clientSessionId, () =>
+        NativePlaidModule.startHeadlessSession(clientSessionId),
+      ),
     destroy: () => destroySession(clientSessionId),
   };
 }


### PR DESCRIPTION
## Summary
- keep session callbacks associated with the session that created them
- bind session actions to their original native session
- add cleanup support and regression coverage

## Validation
- npm test -- --runInBand
- npm run build
- npm run lint
- npm run check:package
- npm pack --dry-run
- Android testDebugUnitTest
- iOS simulator build