### PR TITLE
Fix Identity Verification session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,33 @@ await session.open();
 Pass `true` to `session.open(true)` to request full-screen presentation on iOS.
 The default presentation is used when this argument is omitted or `false`.
 
+## Identity Verification
+
+Identity Verification sessions use a dedicated creation function because IDV
+flows do not emit the Link `onLoad` callback.
+
+```ts
+import { createPlaidIdentityVerificationSession } from "react-native-plaid-link-sdk";
+
+const session = await createPlaidIdentityVerificationSession({
+  token: "#GENERATED_IDENTITY_VERIFICATION_LINK_TOKEN#",
+  onSuccess: (success) => {
+    console.log("Success", success);
+  },
+  onExit: (exit) => {
+    console.log("Exit", exit);
+  },
+  onEvent: (event) => {
+    console.log("Event", event);
+  },
+});
+
+await session.open();
+```
+
+The promise resolves as soon as the native IDV session is created. Do not wait
+for `onLoad` before opening an Identity Verification session.
+
 ## Layer
 
 Layer uses a dedicated session object. Submit user data once the Layer session is

--- a/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt
@@ -60,6 +60,27 @@ class ReactNativePlaidLinkSdkModule : Module() {
       }
     }
 
+    AsyncFunction("createPlaidIdentityVerificationSession") { token: String, promise: Promise ->
+      try {
+        val activity = requireActivity()
+        Plaid.setLinkEventListener { event -> sendEvent("PlaidLink.onEvent", event.toWritableMap()) }
+        val config = LinkTokenConfiguration.Builder()
+          .token(token)
+          .build()
+        linkSession = Plaid.createPlaidLinkSession(activity, config)
+        activeSession = linkSession
+        sessionCreationError = null
+        promise.resolve(null)
+      } catch (error: Throwable) {
+        sessionCreationError = error
+        promise.reject(
+          "IDENTITY_VERIFICATION_SESSION_CREATE_ERROR",
+          error.message ?: "Failed to create Identity Verification session",
+          error,
+        )
+      }
+    }
+
     AsyncFunction("createPlaidLayerSession") { token: String, promise: Promise ->
       try {
         val activity = requireActivity()

--- a/ios/src/ReactNativePlaidLinkSdkModule.swift
+++ b/ios/src/ReactNativePlaidLinkSdkModule.swift
@@ -70,6 +70,40 @@ public class ReactNativePlaidLinkSdkModule: Module {
             }
         }
 
+        AsyncFunction(ModuleFunctionName.createPlaidIdentityVerificationSession.rawValue) {
+            (token: String, promise: Promise) in
+            let onSuccess: OnSuccessHandler = { [weak self] success in
+                self?.sendEvent(ModuleEventName.onSuccess.rawValue, success.asDictionary)
+            }
+
+            let onExit: OnExitHandler = { [weak self] exit in
+                self?.sendEvent(ModuleEventName.onExit.rawValue, exit.asDictionary)
+                self?.linkSession = nil
+            }
+
+            let onEvent: OnEventHandler = { [weak self] event in
+                self?.sendEvent(ModuleEventName.onEvent.rawValue, event.asDictionary)
+            }
+
+            let config = LinkTokenConfiguration(
+                token: token,
+                onSuccess: onSuccess,
+                onExit: onExit,
+                onEvent: onEvent,
+                onLoad: nil
+            )
+
+            do {
+                let session = try Plaid.createPlaidLinkSession(configuration: config)
+                self.linkSession = session
+                self.sessionCreationError = nil
+                promise.resolve()
+            } catch {
+                self.sessionCreationError = error
+                promise.reject("IDENTITY_VERIFICATION_SESSION_CREATE_ERROR", error.localizedDescription)
+            }
+        }
+
         AsyncFunction(ModuleFunctionName.createPlaidLayerSession.rawValue) { (token: String, promise: Promise) in
             let onSuccess: OnSuccessHandler = { [weak self] success in
                 self?.sendEvent(ModuleEventName.onSuccess.rawValue, success.asDictionary)
@@ -348,6 +382,7 @@ public class ReactNativePlaidLinkSdkModule: Module {
     /// Function names that the module can call from JavaScript.
     enum ModuleFunctionName: String, CaseIterable {
         case createPlaidLinkSession
+        case createPlaidIdentityVerificationSession
         case createPlaidLayerSession
         case createPlaidHeadlessSession
         case openLinkSession

--- a/src/ReactNativePlaidLinkSdk.types.ts
+++ b/src/ReactNativePlaidLinkSdk.types.ts
@@ -801,6 +801,24 @@ export interface LinkTokenConfiguration {
   onLoad?: () => void;
 }
 
+/** Configuration for an Identity Verification Link session. */
+export interface IdentityVerificationTokenConfiguration {
+  /** The Identity Verification link token created by your server. */
+  token: string;
+
+  /** Called when the Identity Verification flow completes successfully. */
+  onSuccess: LinkSuccessListener;
+
+  /** Called when the user exits the Identity Verification flow. */
+  onExit: LinkExitListener;
+
+  /** Called as the user reaches points in the Identity Verification flow. */
+  onEvent: LinkOnEventListener;
+
+  /** Identity Verification sessions do not emit onLoad. */
+  onLoad?: never;
+}
+
 export interface LayerTokenConfiguration {
   /** The link-token your server retrieved from the /link/token/create endpoint. */
   token: string;

--- a/src/ReactNativePlaidLinkSdk.types.ts
+++ b/src/ReactNativePlaidLinkSdk.types.ts
@@ -814,9 +814,6 @@ export interface IdentityVerificationTokenConfiguration {
 
   /** Called as the user reaches points in the Identity Verification flow. */
   onEvent: LinkOnEventListener;
-
-  /** Identity Verification sessions do not emit onLoad. */
-  onLoad?: never;
 }
 
 export interface LayerTokenConfiguration {

--- a/src/ReactNativePlaidLinkSdkModule.ts
+++ b/src/ReactNativePlaidLinkSdkModule.ts
@@ -8,6 +8,7 @@ import {
 declare class ReactNativePlaidLinkSdkModule extends NativeModule<ReactNativePlaidLinkSdkModuleEvents> {
   sdkVersion: string;
   createPlaidLinkSession(token: string): Promise<void>;
+  createPlaidIdentityVerificationSession(token: string): Promise<void>;
   createPlaidLayerSession(token: string): Promise<void>;
   createPlaidHeadlessSession(token: string): Promise<void>;
   openLinkSession(fullScreen: boolean): Promise<void>;

--- a/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
+++ b/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
@@ -9,6 +9,8 @@ const mockNativeModule = {
 
   createPlaidLinkSession: jest.fn(() => Promise.resolve()),
 
+  createPlaidIdentityVerificationSession: jest.fn(() => Promise.resolve()),
+
   createPlaidLayerSession: jest.fn(() => Promise.resolve()),
 
   createPlaidHeadlessSession: jest.fn(() => Promise.resolve()),

--- a/src/__tests__/createPlaidIdentityVerificationSession.test.ts
+++ b/src/__tests__/createPlaidIdentityVerificationSession.test.ts
@@ -1,0 +1,123 @@
+import {
+  LinkEvent,
+  LinkEventName,
+  LinkExit,
+  LinkSuccess,
+} from "../ReactNativePlaidLinkSdk.types";
+import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import { createPlaidIdentityVerificationSession } from "../index";
+
+describe("createPlaidIdentityVerificationSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (NativePlaidModule as any).__clearListeners();
+  });
+
+  it("creates and returns an IDV session without waiting for onLoad", async () => {
+    const session = await createPlaidIdentityVerificationSession({
+      token: "identity-verification-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    expect(
+      NativePlaidModule.createPlaidIdentityVerificationSession,
+    ).toHaveBeenCalledWith("identity-verification-token");
+    expect(session).toHaveProperty("open");
+    expect(NativePlaidModule.addListener).toHaveBeenCalledTimes(3);
+  });
+
+  it("opens the IDV session with the existing Link presentation API", async () => {
+    const session = await createPlaidIdentityVerificationSession({
+      token: "identity-verification-token",
+      onSuccess: jest.fn(),
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    await session.open();
+    await session.open(true);
+
+    expect(NativePlaidModule.openLinkSession).toHaveBeenNthCalledWith(1, false);
+    expect(NativePlaidModule.openLinkSession).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it("forwards IDV success, exit, and event callbacks", async () => {
+    const onSuccess = jest.fn();
+    const onExit = jest.fn();
+    const onEvent = jest.fn();
+
+    await createPlaidIdentityVerificationSession({
+      token: "identity-verification-token",
+      onSuccess,
+      onExit,
+      onEvent,
+    });
+
+    const event: LinkEvent = {
+      eventName: LinkEventName.IDENTITY_VERIFICATION_START_STEP,
+      metadata: {
+        linkSessionId: "idv-session",
+        timestamp: "2026-08-28T12:00:00Z",
+        metadataJson: "{}",
+      },
+    };
+    const exit: LinkExit = {
+      metadata: {
+        linkSessionId: "idv-session",
+        requestId: "request-id",
+      },
+    };
+
+    (NativePlaidModule as any).__triggerEvent("PlaidLink.onEvent", event);
+    (NativePlaidModule as any).__triggerEvent("PlaidLink.onExit", exit);
+
+    expect(onEvent).toHaveBeenCalledWith(event);
+    expect(onExit).toHaveBeenCalledWith(exit);
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    await createPlaidIdentityVerificationSession({
+      token: "second-identity-verification-token",
+      onSuccess,
+      onExit: jest.fn(),
+      onEvent: jest.fn(),
+    });
+
+    const success: LinkSuccess = {
+      publicToken: "",
+      metadata: {
+        accounts: [],
+        linkSessionId: "second-idv-session",
+      },
+    };
+    (NativePlaidModule as any).__triggerEvent("PlaidLink.onSuccess", success);
+
+    expect(onSuccess).toHaveBeenCalledWith(success);
+  });
+
+  it("rejects native creation errors and removes its listeners", async () => {
+    (
+      NativePlaidModule.createPlaidIdentityVerificationSession as jest.Mock
+    ).mockRejectedValueOnce(new Error("IDV session creation failed"));
+
+    await expect(
+      createPlaidIdentityVerificationSession({
+        token: "invalid-token",
+        onSuccess: jest.fn(),
+        onExit: jest.fn(),
+        onEvent: jest.fn(),
+      }),
+    ).rejects.toThrow("IDV session creation failed");
+
+    expect(
+      (NativePlaidModule as any).__getListenerCount("PlaidLink.onSuccess"),
+    ).toBe(0);
+    expect(
+      (NativePlaidModule as any).__getListenerCount("PlaidLink.onExit"),
+    ).toBe(0);
+    expect(
+      (NativePlaidModule as any).__getListenerCount("PlaidLink.onEvent"),
+    ).toBe(0);
+  });
+});

--- a/src/__tests__/native-callback-contract.test.ts
+++ b/src/__tests__/native-callback-contract.test.ts
@@ -175,6 +175,9 @@ describe("native callback payload contract", () => {
   const androidSource = readRepoFile(
     "android/src/main/java/expo/modules/plaidlinksdk/PlaidResultMappers.kt",
   );
+  const androidModuleSource = readRepoFile(
+    "android/src/main/java/expo/modules/plaidlinksdk/ReactNativePlaidLinkSdkModule.kt",
+  );
 
   it("keeps iOS callback dictionary keys aligned with the RN contract", () => {
     const success = extractCurlyBlock(iosSource, "extension LinkSuccess");
@@ -261,6 +264,26 @@ describe("native callback payload contract", () => {
     expect(extractKotlinFunctionKeys(androidSource, "accountPayload")).toEqual(
       contract.account,
     );
+  });
+
+  it("creates IDV sessions without an onLoad callback on both platforms", () => {
+    const iosIdvCreate = extractCurlyBlock(
+      iosSource,
+      "AsyncFunction(ModuleFunctionName.createPlaidIdentityVerificationSession.rawValue)",
+    );
+    const androidIdvCreate = extractCurlyBlock(
+      androidModuleSource,
+      'AsyncFunction("createPlaidIdentityVerificationSession")',
+    );
+
+    expect(iosIdvCreate).toContain("onLoad: nil");
+    expect(iosIdvCreate).toContain("self.linkSession = session");
+    expect(iosIdvCreate).toContain("promise.resolve()");
+    expect(iosIdvCreate).not.toContain("OnLoadHandler");
+
+    expect(androidIdvCreate).toContain("linkSession =");
+    expect(androidIdvCreate).toContain("promise.resolve(null)");
+    expect(androidIdvCreate).not.toContain("OnLoadCallback");
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   LinkEventName,
   LinkSuccess,
   LinkTokenConfiguration,
+  IdentityVerificationTokenConfiguration,
   PlaidLinkSession,
   LayerTokenConfiguration,
   PlaidLayerSession,
@@ -91,6 +92,59 @@ export async function createPlaidLinkSession(
   await NativePlaidModule.createPlaidLinkSession(config.token);
 
   config.onLoad?.();
+
+  return {
+    open: (fullScreen = false) => NativePlaidModule.openLinkSession(fullScreen),
+  };
+}
+
+/**
+ * Creates an Identity Verification session without waiting for an onLoad
+ * callback, which Identity Verification flows do not emit.
+ */
+export async function createPlaidIdentityVerificationSession(
+  config: IdentityVerificationTokenConfiguration,
+): Promise<PlaidLinkSession> {
+  cleanupListeners();
+
+  successSub = NativePlaidModule.addListener(
+    "PlaidLink.onSuccess",
+    (success: LinkSuccess) => {
+      config.onSuccess(success);
+      cleanupListeners({ keepEventListener: true });
+      cleanupAfterPostSuccessHandoffWindow();
+    },
+  );
+
+  exitSub = NativePlaidModule.addListener(
+    "PlaidLink.onExit",
+    (exit: LinkExit) => {
+      config.onExit(exit);
+      cleanupListeners();
+    },
+  );
+
+  eventSub = NativePlaidModule.addListener(
+    "PlaidLink.onEvent",
+    (event: LinkEvent) => {
+      config.onEvent(event);
+      if (
+        postSuccessHandoffCleanupTimeout &&
+        event.eventName === LinkEventName.HANDOFF
+      ) {
+        cleanupListeners();
+      }
+    },
+  );
+
+  try {
+    await NativePlaidModule.createPlaidIdentityVerificationSession(
+      config.token,
+    );
+  } catch (error) {
+    cleanupListeners();
+    throw error;
+  }
 
   return {
     open: (fullScreen = false) => NativePlaidModule.openLinkSession(fullScreen),


### PR DESCRIPTION
## Summary

- add an explicit Identity Verification session API that does not expose or wait for `onLoad`
- create and retain the native Link session before resolving on iOS and Android
- leave the existing `createPlaidLinkSession` behavior unchanged
- document the IDV flow and add JavaScript/native contract coverage

Fixes #968

## Validation

- `npm run build`
- `npm run check:package`
- `npm run lint`
- `npm test -- --runInBand` (115 tests)
- `npm pack --dry-run`
- Android `testDebugUnitTest` build
- iOS simulator example build with code signing disabled
- live sandbox IDV session visibly presented on iOS 26.4 simulator
- live sandbox IDV session visibly presented on Android 15 emulator