### PR TITLE
Prepare 13.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # RELEASES
 
+## LinkKit V13.0.5 — 2026-08-28
+
+### Changes
+
+- Adds an explicit Identity Verification session API that creates and returns
+  the native Link session without waiting for an `onLoad` callback.
+- Leaves the existing `createPlaidLinkSession` behavior unchanged.
+- Leaves Android integration unchanged at `com.plaid.link:sdk-core:6.1.0`.
+- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.
+
+### Android
+
+Android SDK [6.1.0](https://github.com/plaid/plaid-link-android/releases/tag/v6.1.0)
+
+### iOS
+
+iOS SDK [7.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/7.1.0)
+
 ## LinkKit V13.0.4 — 2026-08-04
 
 ### Changes

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,6 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="13.0.4" />
+      android:value="13.0.5" />
   </application>
 </manifest>

--- a/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
@@ -1,5 +1,5 @@
 package expo.modules.plaidlinksdk
 
 internal object RNPlaidLinkSdkVersion {
-  const val SDK_VERSION = "13.0.4"
+  const val SDK_VERSION = "13.0.5"
 }

--- a/ios/src/RNPlaidLinkSdkVersion.swift
+++ b/ios/src/RNPlaidLinkSdkVersion.swift
@@ -15,5 +15,5 @@ public class RNPlaidLinkSdkVersion: NSObject {
     ///
     /// This should match the version specified in package.json.
     /// Update this value when bumping the SDK version.
-    @objc public static let sdkVersion: String = "13.0.4"
+    @objc public static let sdkVersion: String = "13.0.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.4",
+  "version": "13.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "13.0.4",
+      "version": "13.0.5",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.4",
+  "version": "13.0.5",
   "description": "React Native Plaid Link SDK (New Architecture & Expo)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
+++ b/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
@@ -5,7 +5,7 @@ const mockListeners: Record<string, Function[]> = {
 };
 
 const mockNativeModule = {
-  sdkVersion: "13.0.4",
+  sdkVersion: "13.0.5",
 
   createPlaidLinkSession: jest.fn(() => Promise.resolve()),
 


### PR DESCRIPTION
## Summary

- Prepares React Native SDK 13.0.5.
- Releases the explicit Identity Verification session API from #969 without changing the existing `createPlaidLinkSession` behavior.
- Leaves Android unchanged at `com.plaid.link:sdk-core:6.1.0`.
- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.

## 13.0.5 Changelog

- Adds an explicit Identity Verification session API that creates and returns the native Link session without waiting for an `onLoad` callback.
- Leaves the existing `createPlaidLinkSession` behavior unchanged.
- Leaves Android integration unchanged at `com.plaid.link:sdk-core:6.1.0`.
- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.

## Testing

- `npm run check:linkkit`
- `npm run lint`
- `npm test -- --coverage --no-watch --passWithNoTests --watchman=false` (115 tests)
- `npm run build`
- `npm run check:package`
- `npm pack --dry-run --json --cache /private/tmp/react-native-plaid-link-sdk-13.0.5-npm-cache`

## Notes

- `npm publish` is intentionally not run from this PR.
- No native Android or iOS SDK artifacts are changed in this release.