### PR TITLE
Add actionable v13 migration diagnostics

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,6 +49,11 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
+      - name: Packed TypeScript API check
+        run: npm run check:typescript-api
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+
       - name: Pack dry run
         run: npm run pack:dry-run
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,36 +13,39 @@ before writing any Plaid code.
 import { createPlaidLinkSession } from "react-native-plaid-link-sdk";
 ```
 
-These do not exist in v13 and will fail to compile:
+These pre-v13 names are retained only as migration diagnostics and are not
+callable:
 
 ```ts
-import { create, open } from "react-native-plaid-link-sdk";      // TS2614
-import { EmbeddedLinkView } from "react-native-plaid-link-sdk";  // TS2614
-import { usePlaidEmitter } from "react-native-plaid-link-sdk";   // TS2614
+import { create, open } from "react-native-plaid-link-sdk";
+import { EmbeddedLinkView } from "react-native-plaid-link-sdk";
 ```
 
-TypeScript reports these as `TS2614 ... Did you mean to use 'import create from
+Using one reports `TS2349: This expression is not callable` followed by an exact
+v13 replacement, such as `Removed in v13. Use await
+createPlaidLinkSession(config), then call await session.open() on the returned
+session.` JavaScript callers receive the same guidance as a runtime error.
+
+Older v13 releases reported `TS2614 ... Did you mean to use 'import create from
 "react-native-plaid-link-sdk"' instead?`. **That suggestion is wrong.** The
-package has a default export, so TypeScript assumes you meant to import it, but
-the default export is the native module object — not these functions. Following
-the hint just moves the error one line down to `TS2349: This expression is not
-callable`. Use the named exports below.
+deprecated default export is the native module object, not `create`, `open`, or
+`EmbeddedLinkView`. Do not follow the default-import suggestion.
 
 ## If you were about to write pre-v13 code
 
-| Pre-v13 | v13 |
-| --- | --- |
-| `create(config)` | `await createPlaidLinkSession(config)` |
-| `open({ onSuccess, onExit })` | `await session.open()` — callbacks now go to the create call |
-| `openLink({ tokenConfig, onSuccess })` | `createPlaidLinkSession(...)` then `session.open()` |
-| `<PlaidLink>` component | Build your own button, call `createPlaidLinkSession` |
-| `usePlaidEmitter(listener)` | Pass `onEvent` to the create call |
-| `submit(data)` | `await session.submit(data)` on a Layer session |
-| `EmbeddedLinkView` | `PlaidEmbeddedSearchView` |
-| `syncFinanceKit(token, bool, bool, cb)` | `await syncFinanceKit({ token, ... })` |
-| `iOSPresentationStyle: FULL_SCREEN` | `await session.open(true)` |
-| `destroy()` | Not needed — each create call resets session state |
-| `dismissLink()` | No replacement in v13 |
+| Pre-v13                                 | v13                                                          |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `create(config)`                        | `await createPlaidLinkSession(config)`                       |
+| `open({ onSuccess, onExit })`           | `await session.open()` — callbacks now go to the create call |
+| `openLink({ tokenConfig, onSuccess })`  | `createPlaidLinkSession(...)` then `session.open()`          |
+| `<PlaidLink>` component                 | Build your own button, call `createPlaidLinkSession`         |
+| `usePlaidEmitter(listener)`             | Pass `onEvent` to the create call                            |
+| `submit(data)`                          | `await session.submit(data)` on a Layer session              |
+| `EmbeddedLinkView`                      | `PlaidEmbeddedSearchView`                                    |
+| `syncFinanceKit(token, bool, bool, cb)` | `await syncFinanceKit({ token, ... })`                       |
+| `iOSPresentationStyle: FULL_SCREEN`     | `await session.open(true)`                                   |
+| `destroy()`                             | Not needed — each create call resets session state           |
+| `dismissLink()`                         | No replacement in v13                                        |
 
 The two changes that trip up most generated code: **callbacks moved from `open`
 to the create call**, and **every create function is `async`**.
@@ -52,6 +55,8 @@ to the create call**, and **every create function is `async`**.
 Functions — `createPlaidLinkSession`, `createPlaidIdentityVerificationSession`,
 `createPlaidLayerSession`, `createPlaidHeadlessSession`, `syncFinanceKit`.
 
+Constant — `sdkVersion`.
+
 Component — `PlaidEmbeddedSearchView` (with `PlaidEmbeddedSearchViewProps`).
 
 Types and enums — `LinkSuccess`, `LinkExit`, `LinkEvent`, `LinkEventName`,
@@ -59,8 +64,8 @@ Types and enums — `LinkSuccess`, `LinkExit`, `LinkEvent`, `LinkEventName`,
 `PlaidHeadlessSession`, `SubmissionData`, `FinanceKitSyncBehavior`, and the
 other types in `ReactNativePlaidLinkSdk.types`.
 
-Default export — the native module instance. The only supported use is reading
-`.sdkVersion`. Do not call Link APIs on it.
+Default export — deprecated native module instance. Do not use it; use the named
+exports, including `sdkVersion`. It will be removed in the next major version.
 
 ## Standard Link
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ Plaid Dashboard for the environment you are testing.
 ### TS2614: Module '"react-native-plaid-link-sdk"' has no exported member 'create'
 
 v13 replaced the global `create` and `open` functions with session objects, so
-pre-v13 imports no longer compile. TypeScript reports one error per removed
-name:
+pre-v13 usages no longer compile. Older v13 releases report one error per
+removed import:
 
 ```
 error TS2614: Module '"react-native-plaid-link-sdk"' has no exported member 'create'.
@@ -304,8 +304,7 @@ error TS2614: Module '"react-native-plaid-link-sdk"' has no exported member 'Emb
   Did you mean to use 'import EmbeddedLinkView from "react-native-plaid-link-sdk"' instead?
 ```
 
-The same error appears for `usePlaidEmitter`, `submit`, `destroy`, and
-`dismissLink`.
+The same error appears for other removed APIs.
 
 **Do not follow the suggested default import.** The package does have a default
 export, but it is the native module object, not these functions. Rewriting the
@@ -317,20 +316,32 @@ error TS2349: This expression is not callable.
   Type 'ReactNativePlaidLinkSdkModule' has no call signatures.
 ```
 
+Newer v13 releases retain `create`, `open`, and `EmbeddedLinkView` only as
+deprecated migration diagnostics. Their imports resolve, but trying to use one
+produces `TS2349` with the exact replacement in its type:
+
+```
+error TS2349: This expression is not callable.
+  Type '{ readonly __migration_error__: "Removed in v13. Use await createPlaidLinkSession(config), then call await session.open() on the returned session."; }' has no call signatures.
+```
+
+JavaScript callers receive the same replacement and a migration-guide link in a
+runtime error. These diagnostic exports do not restore the pre-v13 global API.
+
 Use the v13 replacements instead:
 
-| Pre-v13 | v13 |
-| --- | --- |
-| `create(config)` | `await createPlaidLinkSession(config)` |
-| `open({ onSuccess, onExit })` | `await session.open()` — callbacks move to the create call |
-| `openLink({ tokenConfig, ... })` | `createPlaidLinkSession(...)`, then `session.open()` |
-| `<PlaidLink>` component | Build your own button and call `createPlaidLinkSession` |
-| `usePlaidEmitter(listener)` | Pass `onEvent` to the create call |
-| `submit(data)` | `await session.submit(data)` on a Layer session |
-| `EmbeddedLinkView` | `PlaidEmbeddedSearchView` |
-| `syncFinanceKit(token, bool, bool, cb)` | `await syncFinanceKit({ token, ... })` |
-| `destroy()` | Not needed — each create call resets session state |
-| `dismissLink()` | No replacement in v13 |
+| Pre-v13                                 | v13                                                        |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `create(config)`                        | `await createPlaidLinkSession(config)`                     |
+| `open({ onSuccess, onExit })`           | `await session.open()` — callbacks move to the create call |
+| `openLink({ tokenConfig, ... })`        | `createPlaidLinkSession(...)`, then `session.open()`       |
+| `<PlaidLink>` component                 | Build your own button and call `createPlaidLinkSession`    |
+| `usePlaidEmitter(listener)`             | Pass `onEvent` to the create call                          |
+| `submit(data)`                          | `await session.submit(data)` on a Layer session            |
+| `EmbeddedLinkView`                      | `PlaidEmbeddedSearchView`                                  |
+| `syncFinanceKit(token, bool, bool, cb)` | `await syncFinanceKit({ token, ... })`                     |
+| `destroy()`                             | Not needed — each create call resets session state         |
+| `dismissLink()`                         | No replacement in v13                                      |
 
 The [v13 migration guide](./V13_MIGRATION_GUIDE.md) has full before and after
 examples for every flow.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -8,7 +8,7 @@ import {
   View,
   StyleSheet,
 } from "react-native";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
+import { sdkVersion } from "react-native-plaid-link-sdk";
 
 import { styles } from "./styles/common";
 import { Screen, SCREENS } from "./types/types";
@@ -36,9 +36,7 @@ export default function App() {
     <SafeAreaView style={[styles.container, styles.androidSafeArea]}>
       <ScrollView style={styles.container}>
         <Text style={styles.header}>LinkKit Examples</Text>
-        <Text style={styles.sdkVersion}>
-          SDK: {ReactNativePlaidLinkSdk.sdkVersion}
-        </Text>
+        <Text style={styles.sdkVersion}>SDK: {sdkVersion}</Text>
         {SCREENS.map((s) => (
           <TouchableOpacity
             key={s.key}

--- a/example/screens/PlaidEmbeddedSearchScreen.tsx
+++ b/example/screens/PlaidEmbeddedSearchScreen.tsx
@@ -13,8 +13,8 @@ import {
   LinkEvent,
   LinkSuccess,
   PlaidEmbeddedSearchView,
+  sdkVersion,
 } from "react-native-plaid-link-sdk";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
 import { SdkVersionView, TokenInputView } from "../components/components";
 import { styles } from "../styles/common";
 import { isValidToken } from "../utils/validation";
@@ -74,7 +74,7 @@ export function PlaidEmbeddedSearchScreen({ onBack }: Props) {
 
         <View style={styles.content}>
           <Text style={styles.title}>Plaid Embedded Search Example</Text>
-          <SdkVersionView version={ReactNativePlaidLinkSdk.sdkVersion} />
+          <SdkVersionView version={sdkVersion} />
 
           <TokenInputView token={token} onTokenChange={setToken} />
 

--- a/example/screens/PlaidLayerSessionScreen.tsx
+++ b/example/screens/PlaidLayerSessionScreen.tsx
@@ -14,8 +14,8 @@ import {
   LinkSuccess,
   PlaidLayerSession,
   LinkEventName,
+  sdkVersion,
 } from "react-native-plaid-link-sdk";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
 import {
   ErrorView,
   PrimaryButton,
@@ -137,7 +137,7 @@ export function PlaidLayerSessionScreen({ onBack }: Props) {
 
         <View style={styles.content}>
           <Text style={styles.title}>Plaid Layer Session Example</Text>
-          <SdkVersionView version={ReactNativePlaidLinkSdk.sdkVersion} />
+          <SdkVersionView version={sdkVersion} />
 
           <TokenInputView token={token} onTokenChange={setToken} />
 

--- a/example/screens/PlaidLinkHeadlessSessionScreen.tsx
+++ b/example/screens/PlaidLinkHeadlessSessionScreen.tsx
@@ -14,8 +14,8 @@ import {
   LinkSuccess,
   PlaidHeadlessSession,
   LinkEventName,
+  sdkVersion,
 } from "react-native-plaid-link-sdk";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
 import {
   ErrorView,
   PrimaryButton,
@@ -124,7 +124,7 @@ export function PlaidLinkHeadlessSessionScreen({ onBack }: Props) {
 
         <View style={styles.content}>
           <Text style={styles.title}>Plaid Link Headless Session Example</Text>
-          <SdkVersionView version={ReactNativePlaidLinkSdk.sdkVersion} />
+          <SdkVersionView version={sdkVersion} />
 
           <View style={headlessStyles.warningBox}>
             <Text style={headlessStyles.warningIcon}>⚠️</Text>

--- a/example/screens/PlaidLinkSessionScreen.tsx
+++ b/example/screens/PlaidLinkSessionScreen.tsx
@@ -7,8 +7,8 @@ import {
   LinkSuccess,
   PlaidLinkSession,
   LinkEventName,
+  sdkVersion,
 } from "react-native-plaid-link-sdk";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
 import {
   ConnectButton,
   ErrorView,
@@ -98,7 +98,7 @@ export function PlaidLinkSessionScreen({ onBack }: Props) {
 
         <View style={styles.content}>
           <Text style={styles.title}>Plaid Link Session Example</Text>
-          <SdkVersionView version={ReactNativePlaidLinkSdk.sdkVersion} />
+          <SdkVersionView version={sdkVersion} />
 
           <TokenInputView token={token} onTokenChange={setToken} />
 

--- a/example/screens/SyncFinanceKitScreen.tsx
+++ b/example/screens/SyncFinanceKitScreen.tsx
@@ -13,8 +13,8 @@ import {
 import {
   syncFinanceKit,
   FinanceKitSyncBehavior,
+  sdkVersion,
 } from "react-native-plaid-link-sdk";
-import ReactNativePlaidLinkSdk from "react-native-plaid-link-sdk";
 import {
   ErrorView,
   SdkVersionView,
@@ -99,7 +99,7 @@ export function SyncFinanceKitScreen({ onBack }: Props) {
 
         <View style={styles.content}>
           <Text style={styles.title}>Sync FinanceKit Example</Text>
-          <SdkVersionView version={ReactNativePlaidLinkSdk.sdkVersion} />
+          <SdkVersionView version={sdkVersion} />
 
           <TokenInputView token={token} onTokenChange={setToken} />
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build": "expo-module build",
     "check:linkkit": "node scripts/validate-linkkit-xcframework.js",
     "check:package": "node scripts/check-package-entrypoints.js",
+    "check:typescript-api": "node scripts/check-typescript-api.js",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "pack:dry-run": "node scripts/npm-dry-run.js pack",

--- a/scripts/check-typescript-api.js
+++ b/scripts/check-typescript-api.js
@@ -1,0 +1,165 @@
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const tempRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "react-native-plaid-link-sdk-types-")
+);
+
+function fail(message) {
+  console.error(`TypeScript API check failed: ${message}`);
+  process.exitCode = 1;
+}
+
+try {
+  const tarballOutput = execFileSync(
+    process.execPath,
+    [path.join(root, "scripts", "pack-compat-tarball.js"), tempRoot],
+    { cwd: root, encoding: "utf8" }
+  );
+  const tarballPath = tarballOutput.trim().split(/\r?\n/).at(-1);
+  const extractRoot = path.join(tempRoot, "extract");
+  const consumerRoot = path.join(tempRoot, "consumer");
+  const installedPackage = path.join(
+    consumerRoot,
+    "node_modules",
+    "react-native-plaid-link-sdk"
+  );
+
+  fs.mkdirSync(extractRoot, { recursive: true });
+  fs.mkdirSync(path.dirname(installedPackage), { recursive: true });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", extractRoot]);
+  fs.renameSync(path.join(extractRoot, "package"), installedPackage);
+
+  fs.writeFileSync(
+    path.join(consumerRoot, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: "commonjs",
+          moduleResolution: "node",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "es2020",
+        },
+        files: ["supported.ts"],
+      },
+      null,
+      2
+    )
+  );
+
+  fs.writeFileSync(
+    path.join(consumerRoot, "supported.ts"),
+    `import {
+  FinanceKitSyncBehavior,
+  PlaidEmbeddedSearchView,
+  createPlaidHeadlessSession,
+  createPlaidLayerSession,
+  createPlaidLinkSession,
+  sdkVersion,
+  syncFinanceKit,
+} from "react-native-plaid-link-sdk";
+
+async function exerciseSupportedApi(token: string) {
+  const link = await createPlaidLinkSession({
+    token,
+    onSuccess: () => {},
+    onExit: () => {},
+    onEvent: () => {},
+  });
+  await link.open();
+
+  const layer = await createPlaidLayerSession({
+    token,
+    onSuccess: () => {},
+    onExit: () => {},
+    onEvent: () => {},
+  });
+  await layer.submit({ phoneNumber: "+14155550017" });
+  await layer.open();
+
+  const headless = await createPlaidHeadlessSession({
+    token,
+    onSuccess: () => {},
+    onExit: () => {},
+    onEvent: () => {},
+  });
+  await headless.start();
+
+  await syncFinanceKit({
+    token,
+    syncBehavior: FinanceKitSyncBehavior.LIVE,
+  });
+
+  return { PlaidEmbeddedSearchView, sdkVersion };
+}
+
+void exerciseSupportedApi;
+`
+  );
+
+  const tscPath = require.resolve("typescript/bin/tsc");
+  execFileSync(process.execPath, [tscPath, "-p", "tsconfig.json"], {
+    cwd: consumerRoot,
+    encoding: "utf8",
+  });
+
+  fs.writeFileSync(
+    path.join(consumerRoot, "removed.ts"),
+    `import { create, open, EmbeddedLinkView } from "react-native-plaid-link-sdk";
+
+create({ token: "link-token" });
+open({});
+EmbeddedLinkView({});
+`
+  );
+
+  const removedResult = spawnSync(
+    process.execPath,
+    [
+      tscPath,
+      "--noEmit",
+      "--pretty",
+      "false",
+      "--skipLibCheck",
+      "--strict",
+      "--moduleResolution",
+      "node",
+      "removed.ts",
+    ],
+    { cwd: consumerRoot, encoding: "utf8" }
+  );
+  const diagnostics = `${removedResult.stdout || ""}${
+    removedResult.stderr || ""
+  }`;
+
+  if (removedResult.status === 0) {
+    fail("removed APIs unexpectedly compiled successfully.");
+  }
+
+  for (const replacement of [
+    "Use await createPlaidLinkSession(config), then call await session.open()",
+    "Call await session.open() on the session returned by createPlaidLinkSession(config)",
+    "Use PlaidEmbeddedSearchView",
+  ]) {
+    if (!diagnostics.includes(replacement)) {
+      fail(`missing migration diagnostic: ${replacement}`);
+    }
+  }
+
+  if (diagnostics.includes("Did you mean to use 'import")) {
+    fail("TypeScript still suggests the incorrect default import.");
+  }
+
+  if (!process.exitCode) {
+    console.log(
+      "Packed TypeScript API is valid and removed APIs provide actionable diagnostics."
+    );
+  }
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/src/__tests__/removed-api-diagnostics.test.ts
+++ b/src/__tests__/removed-api-diagnostics.test.ts
@@ -1,0 +1,35 @@
+import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
+import ReactNativePlaidLinkSdk, {
+  EmbeddedLinkView,
+  create,
+  open,
+  sdkVersion,
+} from "../index";
+
+describe("removed API diagnostics", () => {
+  it.each([
+    [
+      "create",
+      create,
+      "Use await createPlaidLinkSession(config), then call await session.open()",
+    ],
+    [
+      "open",
+      open,
+      "Call await session.open() on the session returned by createPlaidLinkSession(config)",
+    ],
+    ["EmbeddedLinkView", EmbeddedLinkView, "Use PlaidEmbeddedSearchView"],
+  ])("throws an actionable runtime error for %s", (name, api, replacement) => {
+    expect(() => (api as unknown as () => never)()).toThrow(
+      `${name} was removed in react-native-plaid-link-sdk v13. ${replacement}`,
+    );
+  });
+
+  it("exports sdkVersion as a named value", () => {
+    expect(sdkVersion).toBe(NativePlaidModule.sdkVersion);
+  });
+
+  it("preserves the deprecated default export in v13", () => {
+    expect(ReactNativePlaidLinkSdk).toBe(NativePlaidModule);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,52 @@ import {
 } from "./ReactNativePlaidLinkSdk.types";
 import NativePlaidModule from "./ReactNativePlaidLinkSdkModule";
 
+const V13_MIGRATION_GUIDE_URL =
+  "https://github.com/plaid/react-native-plaid-link-sdk/blob/master/V13_MIGRATION_GUIDE.md";
+
+function removedApi(name: string, replacement: string): () => never {
+  return () => {
+    throw new Error(
+      `${name} was removed in react-native-plaid-link-sdk v13. ${replacement} See ${V13_MIGRATION_GUIDE_URL}`,
+    );
+  };
+}
+
+/**
+ * @deprecated Removed in v13. Use `await createPlaidLinkSession(config)`, then
+ * call `await session.open()` on the returned session.
+ */
+export const create = removedApi(
+  "create",
+  "Use await createPlaidLinkSession(config), then call await session.open() on the returned session.",
+) as unknown as {
+  readonly __migration_error__: "Removed in v13. Use await createPlaidLinkSession(config), then call await session.open() on the returned session.";
+};
+
+/**
+ * @deprecated Removed in v13. Call `await session.open()` on the session
+ * returned by `createPlaidLinkSession(config)`.
+ */
+export const open = removedApi(
+  "open",
+  "Call await session.open() on the session returned by createPlaidLinkSession(config). Move onSuccess, onExit, and onEvent callbacks to the create call.",
+) as unknown as {
+  readonly __migration_error__: "Removed in v13. Call await session.open() on the session returned by createPlaidLinkSession(config). Move callbacks to the create call.";
+};
+
+/**
+ * @deprecated Removed in v13. Use `PlaidEmbeddedSearchView`.
+ */
+export const EmbeddedLinkView = removedApi(
+  "EmbeddedLinkView",
+  "Use PlaidEmbeddedSearchView.",
+) as unknown as {
+  readonly __migration_error__: "Removed in v13. Use PlaidEmbeddedSearchView.";
+};
+
+/** The React Native Plaid Link SDK version reported by the native module. */
+export const sdkVersion = NativePlaidModule.sdkVersion;
+
 type Subscription = ReturnType<typeof NativePlaidModule.addListener>;
 
 let successSub: Subscription | null = null;
@@ -251,5 +297,11 @@ export {
   PlaidEmbeddedSearchView,
   type PlaidEmbeddedSearchViewProps,
 } from "./PlaidEmbeddedSearchView";
-export { default } from "./ReactNativePlaidLinkSdkModule";
+
+/**
+ * @deprecated Use the package's named exports. Use `sdkVersion` to read the SDK
+ * version. The default export exposes internal native-module methods and will
+ * be removed in the next major version.
+ */
+export default NativePlaidModule;
 export * from "./ReactNativePlaidLinkSdk.types";


### PR DESCRIPTION
## Summary

- Add deprecated, deliberately non-callable migration diagnostics for the removed `create`, `open`, and `EmbeddedLinkView` APIs.
- Include exact v13 replacements in TypeScript declaration errors and matching JavaScript runtime errors.
- Add a named `sdkVersion` export, migrate all examples to it, and deprecate the raw native-module default export without removing it in v13.
- Add a packed-tarball TypeScript consumer check covering supported APIs and removed-API diagnostics.
- Update README and AGENTS guidance for the new compiler behavior.

This does not restore the pre-v13 global API. It turns stale usage into actionable compiler guidance while preserving the session-based API.

## Testing

- [x] `npm run lint`
- [x] `npm test -- --coverage --no-watch --passWithNoTests --runInBand` — 120 tests passed
- [x] `npm run build`
- [x] `npm exec tsc -- --noEmit` in `example/`
- [x] `npm run check:package`
- [x] `npm run check:typescript-api`
- [x] `npm run pack:dry-run`
- [x] `npm run publish:dry-run`
- [x] iOS manually tested or not applicable — TypeScript/package-only change
- [x] Android manually tested or not applicable — TypeScript/package-only change

## Documentation

- [x] Updated README and AGENTS guidance.
- [ ] This PR does not change developer-facing behavior.

## Release impact

- [ ] Public API is unchanged.
- [x] Public API change is intentional and documented.
- [x] Package contents or publish behavior changed; pack and publish dry runs passed.

## Result

Before, TypeScript suggested an incorrect default import for removed names. After this change, their first use fails with the exact public replacement, and the packed-package regression check ensures that the incorrect suggestion cannot return.