### PR TITLE
Prepare 13.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # RELEASES
 
+## LinkKit V13.1.0 — 2026-08-31
+
+### Changes
+
+- Adds deprecated migration diagnostics for the removed `create`, `open`, and
+  `EmbeddedLinkView` APIs. TypeScript and JavaScript errors now identify the
+  corresponding v13 session API instead of suggesting an incorrect default
+  import.
+- Adds a named `sdkVersion` export and deprecates the raw native-module default
+  export. The default export remains available in v13 for compatibility.
+- Adds packaged guidance for AI coding agents and expands troubleshooting for
+  integrations generated from pre-v13 API knowledge.
+- Adds packed-package TypeScript regression coverage for supported v13 APIs and
+  removed-API diagnostics.
+- Leaves Android integration unchanged at `com.plaid.link:sdk-core:6.1.0`.
+- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.
+
+### Android
+
+Android SDK [6.1.0](https://github.com/plaid/plaid-link-android/releases/tag/v6.1.0)
+
+### iOS
+
+iOS SDK [7.1.0](https://github.com/plaid/plaid-link-ios/releases/tag/v7.1.0)
+
 ## LinkKit V13.0.5 — 2026-08-28
 
 ### Changes

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,6 @@
   <application>
     <meta-data
       android:name="com.plaid.link.react_native"
-      android:value="13.0.5" />
+      android:value="13.1.0" />
   </application>
 </manifest>

--- a/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
+++ b/android/src/main/java/expo/modules/plaidlinksdk/RNPlaidLinkSdkVersion.kt
@@ -1,5 +1,5 @@
 package expo.modules.plaidlinksdk
 
 internal object RNPlaidLinkSdkVersion {
-  const val SDK_VERSION = "13.0.5"
+  const val SDK_VERSION = "13.1.0"
 }

--- a/ios/src/RNPlaidLinkSdkVersion.swift
+++ b/ios/src/RNPlaidLinkSdkVersion.swift
@@ -15,5 +15,5 @@ public class RNPlaidLinkSdkVersion: NSObject {
     ///
     /// This should match the version specified in package.json.
     /// Update this value when bumping the SDK version.
-    @objc public static let sdkVersion: String = "13.0.5"
+    @objc public static let sdkVersion: String = "13.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.5",
+  "version": "13.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-plaid-link-sdk",
-      "version": "13.0.5",
+      "version": "13.1.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-plaid-link-sdk",
-  "version": "13.0.5",
+  "version": "13.1.0",
   "description": "React Native Plaid Link SDK (New Architecture & Expo)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
+++ b/src/__mocks__/ReactNativePlaidLinkSdkModule.ts
@@ -5,7 +5,7 @@ const mockListeners: Record<string, Function[]> = {
 };
 
 const mockNativeModule = {
-  sdkVersion: "13.0.5",
+  sdkVersion: "13.1.0",
 
   createPlaidLinkSession: jest.fn(() => Promise.resolve()),
 


### PR DESCRIPTION
## Summary

- Prepares React Native SDK 13.1.0.
- Releases packaged AI-agent guidance and compiler troubleshooting from #971 and #972.
- Releases actionable migration diagnostics, the named `sdkVersion` export, default-export deprecation, and packed TypeScript regression coverage from #973.
- Leaves Android unchanged at `com.plaid.link:sdk-core:6.1.0`.
- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.

## 13.1.0 Changelog

- Adds deprecated migration diagnostics for removed `create`, `open`, and `EmbeddedLinkView` usage. TypeScript and JavaScript errors identify the corresponding v13 session API instead of suggesting an incorrect default import.
- Adds a named `sdkVersion` export and deprecates the raw native-module default export while preserving it throughout v13.
- Adds packaged guidance for AI coding agents and expanded troubleshooting for integrations generated from pre-v13 API knowledge.
- Adds packed-package TypeScript regression coverage for supported v13 APIs and removed-API diagnostics.
- Leaves Android integration unchanged at `com.plaid.link:sdk-core:6.1.0`.
- Leaves the bundled iOS SDK unchanged at LinkKit 7.1.0.

## Testing

- `npm run check:linkkit`
- `npm run lint`
- `npm test -- --coverage --no-watch --passWithNoTests --watchman=false --runInBand` (120 tests)
- `npm run build`
- `npm run check:package`
- `npm run check:typescript-api`
- `npm run pack:dry-run`
- `npm run publish:dry-run`

## Notes

- `npm publish` is intentionally not run from this PR.
- No native Android or iOS SDK artifacts are changed in this release.