### PR TITLE
Extend v13 migration diagnostics to every removed export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ before writing any Plaid code.
 import { createPlaidLinkSession } from "react-native-plaid-link-sdk";
 ```
 
-These pre-v13 names are retained only as migration diagnostics and are not
-callable:
+Every removed pre-v13 name is retained only as a migration diagnostic and is
+not usable: `create`, `open`, `openLink`, `usePlaidEmitter`, `submit`,
+`destroy`, `dismissLink`, `PlaidLink`, and `EmbeddedLinkView`.
 
 ```ts
 import { create, open } from "react-native-plaid-link-sdk";
@@ -24,12 +25,14 @@ import { EmbeddedLinkView } from "react-native-plaid-link-sdk";
 Using one reports `TS2349: This expression is not callable` followed by an exact
 v13 replacement, such as `Removed in v13. Use await
 createPlaidLinkSession(config), then call await session.open() on the returned
-session.` JavaScript callers receive the same guidance as a runtime error.
+session.` Rendering `PlaidLink` or `EmbeddedLinkView` as JSX reports `TS2786`
+carrying the same replacement. JavaScript callers receive the same guidance as a
+runtime error.
 
 Older v13 releases reported `TS2614 ... Did you mean to use 'import create from
 "react-native-plaid-link-sdk"' instead?`. **That suggestion is wrong.** The
-deprecated default export is the native module object, not `create`, `open`, or
-`EmbeddedLinkView`. Do not follow the default-import suggestion.
+deprecated default export is the native module object, not any of these names.
+Do not follow the default-import suggestion.
 
 ## If you were about to write pre-v13 code
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ error TS2614: Module '"react-native-plaid-link-sdk"' has no exported member 'Emb
   Did you mean to use 'import EmbeddedLinkView from "react-native-plaid-link-sdk"' instead?
 ```
 
-The same error appears for other removed APIs.
+Older v13 releases reported the same error for every other removed API.
 
 **Do not follow the suggested default import.** The package does have a default
 export, but it is the native module object, not these functions. Rewriting the
@@ -316,13 +316,23 @@ error TS2349: This expression is not callable.
   Type 'ReactNativePlaidLinkSdkModule' has no call signatures.
 ```
 
-Newer v13 releases retain `create`, `open`, and `EmbeddedLinkView` only as
-deprecated migration diagnostics. Their imports resolve, but trying to use one
-produces `TS2349` with the exact replacement in its type:
+Newer v13 releases retain every removed pre-v13 name — `create`, `open`,
+`openLink`, `usePlaidEmitter`, `submit`, `destroy`, `dismissLink`, `PlaidLink`,
+and `EmbeddedLinkView` — only as deprecated migration diagnostics. Their imports
+resolve, but trying to use one produces `TS2349` with the exact replacement in
+its type:
 
 ```
 error TS2349: This expression is not callable.
   Type '{ readonly __migration_error__: "Removed in v13. Use await createPlaidLinkSession(config), then call await session.open() on the returned session."; }' has no call signatures.
+```
+
+Rendering `PlaidLink` or `EmbeddedLinkView` as a JSX element reports `TS2786`
+with the same replacement:
+
+```
+error TS2786: 'EmbeddedLinkView' cannot be used as a JSX component.
+  Its type '{ readonly __migration_error__: "Removed in v13. Use PlaidEmbeddedSearchView."; }' is not a valid JSX element type.
 ```
 
 JavaScript callers receive the same replacement and a migration-guide link in a

--- a/scripts/check-typescript-api.js
+++ b/scripts/check-typescript-api.js
@@ -33,6 +33,21 @@ try {
   execFileSync("tar", ["-xzf", tarballPath, "-C", extractRoot]);
   fs.renameSync(path.join(extractRoot, "package"), installedPackage);
 
+  // The JSX fixture below renders removed component exports, which needs React
+  // and its types resolvable from the consumer.
+  for (const specifier of ["react", "react-native", "@types/react"]) {
+    const source = path.join(root, "node_modules", specifier);
+    const target = path.join(consumerRoot, "node_modules", specifier);
+
+    if (!fs.existsSync(source)) {
+      fail(`missing local dependency needed for the JSX check: ${specifier}`);
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.symlinkSync(source, target, "junction");
+  }
+
   fs.writeFileSync(
     path.join(consumerRoot, "tsconfig.json"),
     JSON.stringify(
@@ -110,49 +125,117 @@ void exerciseSupportedApi;
 
   fs.writeFileSync(
     path.join(consumerRoot, "removed.ts"),
-    `import { create, open, EmbeddedLinkView } from "react-native-plaid-link-sdk";
+    `import {
+  EmbeddedLinkView,
+  PlaidLink,
+  create,
+  destroy,
+  dismissLink,
+  open,
+  openLink,
+  submit,
+  usePlaidEmitter,
+} from "react-native-plaid-link-sdk";
 
 create({ token: "link-token" });
 open({});
+openLink({});
+usePlaidEmitter(() => {});
+submit({});
+destroy();
+dismissLink();
 EmbeddedLinkView({});
+PlaidLink({});
 `
   );
 
-  const removedResult = spawnSync(
-    process.execPath,
-    [
-      tscPath,
-      "--noEmit",
-      "--pretty",
-      "false",
-      "--skipLibCheck",
-      "--strict",
-      "--moduleResolution",
-      "node",
-      "removed.ts",
-    ],
-    { cwd: consumerRoot, encoding: "utf8" }
-  );
-  const diagnostics = `${removedResult.stdout || ""}${
-    removedResult.stderr || ""
-  }`;
+  // Agents write removed components as JSX far more often than as calls, so the
+  // element form needs its own coverage.
+  fs.writeFileSync(
+    path.join(consumerRoot, "removed-jsx.tsx"),
+    `import React from "react";
+import { EmbeddedLinkView, PlaidLink } from "react-native-plaid-link-sdk";
 
-  if (removedResult.status === 0) {
-    fail("removed APIs unexpectedly compiled successfully.");
+export const Embedded = () => <EmbeddedLinkView token="link-token" />;
+export const Button = () => <PlaidLink token="link-token" />;
+
+void React;
+`
+  );
+
+  function typecheckRemoved(fileName, extraArgs = []) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        tscPath,
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--skipLibCheck",
+        "--strict",
+        "--moduleResolution",
+        "node",
+        "--target",
+        "es2020",
+        ...extraArgs,
+        fileName,
+      ],
+      { cwd: consumerRoot, encoding: "utf8" }
+    );
+
+    if (result.status === 0) {
+      fail(`removed APIs unexpectedly compiled successfully in ${fileName}.`);
+    }
+
+    return `${result.stdout || ""}${result.stderr || ""}`;
   }
+
+  const callDiagnostics = typecheckRemoved("removed.ts");
+  const jsxDiagnostics = typecheckRemoved("removed-jsx.tsx", [
+    "--jsx",
+    "react",
+    "--esModuleInterop",
+  ]);
+  const diagnostics = `${callDiagnostics}${jsxDiagnostics}`;
 
   for (const replacement of [
     "Use await createPlaidLinkSession(config), then call await session.open()",
     "Call await session.open() on the session returned by createPlaidLinkSession(config)",
     "Use PlaidEmbeddedSearchView",
+    "Pass onEvent to createPlaidLinkSession(config) instead of subscribing separately",
+    "Call await session.submit(data) on the session returned by createPlaidLayerSession(config)",
+    "Build your own button and call await createPlaidLinkSession(config)",
+    "Each create call resets session state, so no teardown is needed",
+    "There is no programmatic dismiss API in v13",
   ]) {
     if (!diagnostics.includes(replacement)) {
       fail(`missing migration diagnostic: ${replacement}`);
     }
   }
 
+  // TS2614 means a removed name has no diagnostic export at all, so TypeScript
+  // falls back to guessing the default import — the exact failure these
+  // diagnostics exist to prevent.
+  if (diagnostics.includes("TS2614")) {
+    fail(
+      "a removed API has no migration diagnostic export; TypeScript reported TS2614 instead."
+    );
+  }
+
   if (diagnostics.includes("Did you mean to use 'import")) {
     fail("TypeScript still suggests the incorrect default import.");
+  }
+
+  for (const [fileName, guidance] of [
+    ["removed-jsx.tsx", "Use PlaidEmbeddedSearchView"],
+    [
+      "removed-jsx.tsx",
+      "Build your own button and call await createPlaidLinkSession(config)",
+    ],
+  ]) {
+    if (!jsxDiagnostics.includes(guidance)) {
+      fail(`missing JSX migration diagnostic in ${fileName}: ${guidance}`);
+    }
   }
 
   if (!process.exitCode) {

--- a/src/__tests__/removed-api-diagnostics.test.ts
+++ b/src/__tests__/removed-api-diagnostics.test.ts
@@ -1,9 +1,15 @@
 import NativePlaidModule from "../ReactNativePlaidLinkSdkModule";
 import ReactNativePlaidLinkSdk, {
   EmbeddedLinkView,
+  PlaidLink,
   create,
+  destroy,
+  dismissLink,
   open,
+  openLink,
   sdkVersion,
+  submit,
+  usePlaidEmitter,
 } from "../index";
 
 describe("removed API diagnostics", () => {
@@ -19,9 +25,55 @@ describe("removed API diagnostics", () => {
       "Call await session.open() on the session returned by createPlaidLinkSession(config)",
     ],
     ["EmbeddedLinkView", EmbeddedLinkView, "Use PlaidEmbeddedSearchView"],
+    [
+      "openLink",
+      openLink,
+      "Use await createPlaidLinkSession(config), then call await session.open()",
+    ],
+    [
+      "usePlaidEmitter",
+      usePlaidEmitter,
+      "Pass onEvent to createPlaidLinkSession(config) instead of subscribing separately",
+    ],
+    [
+      "submit",
+      submit,
+      "Call await session.submit(data) on the session returned by createPlaidLayerSession(config)",
+    ],
+    [
+      "PlaidLink",
+      PlaidLink,
+      "Build your own button and call await createPlaidLinkSession(config)",
+    ],
+    [
+      "destroy",
+      destroy,
+      "Remove the call. Each create call resets session state, so no teardown is needed.",
+    ],
+    [
+      "dismissLink",
+      dismissLink,
+      "Remove the call. There is no programmatic dismiss API in v13.",
+    ],
   ])("throws an actionable runtime error for %s", (name, api, replacement) => {
     expect(() => (api as unknown as () => never)()).toThrow(
       `${name} was removed in react-native-plaid-link-sdk v13. ${replacement}`,
+    );
+  });
+
+  it.each([
+    ["create", create],
+    ["open", open],
+    ["EmbeddedLinkView", EmbeddedLinkView],
+    ["openLink", openLink],
+    ["usePlaidEmitter", usePlaidEmitter],
+    ["submit", submit],
+    ["PlaidLink", PlaidLink],
+    ["destroy", destroy],
+    ["dismissLink", dismissLink],
+  ])("links the migration guide from the %s error", (_name, api) => {
+    expect(() => (api as unknown as () => never)()).toThrow(
+      "https://github.com/plaid/react-native-plaid-link-sdk/blob/master/V13_MIGRATION_GUIDE.md",
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,26 @@ import NativePlaidModule from "./ReactNativePlaidLinkSdkModule";
 const V13_MIGRATION_GUIDE_URL =
   "https://github.com/plaid/react-native-plaid-link-sdk/blob/master/V13_MIGRATION_GUIDE.md";
 
-function removedApi(name: string, replacement: string): () => never {
-  return () => {
+/**
+ * Builds a deprecated export for an API removed in v13.
+ *
+ * The replacement text is single-sourced: it is thrown at runtime and encoded
+ * into the returned type, so `tsc` prints the exact v13 replacement instead of
+ * suggesting the (incorrect) default import. Keeping one source for both
+ * prevents the runtime message and the compiler diagnostic from drifting apart.
+ */
+function migrationDiagnostic<Replacement extends string>(
+  name: string,
+  replacement: Replacement,
+): { readonly __migration_error__: `Removed in v13. ${Replacement}` } {
+  const removed = () => {
     throw new Error(
       `${name} was removed in react-native-plaid-link-sdk v13. ${replacement} See ${V13_MIGRATION_GUIDE_URL}`,
     );
+  };
+
+  return removed as unknown as {
+    readonly __migration_error__: `Removed in v13. ${Replacement}`;
   };
 }
 
@@ -31,33 +46,80 @@ function removedApi(name: string, replacement: string): () => never {
  * @deprecated Removed in v13. Use `await createPlaidLinkSession(config)`, then
  * call `await session.open()` on the returned session.
  */
-export const create = removedApi(
+export const create = migrationDiagnostic(
   "create",
   "Use await createPlaidLinkSession(config), then call await session.open() on the returned session.",
-) as unknown as {
-  readonly __migration_error__: "Removed in v13. Use await createPlaidLinkSession(config), then call await session.open() on the returned session.";
-};
+);
 
 /**
  * @deprecated Removed in v13. Call `await session.open()` on the session
  * returned by `createPlaidLinkSession(config)`.
  */
-export const open = removedApi(
+export const open = migrationDiagnostic(
   "open",
   "Call await session.open() on the session returned by createPlaidLinkSession(config). Move onSuccess, onExit, and onEvent callbacks to the create call.",
-) as unknown as {
-  readonly __migration_error__: "Removed in v13. Call await session.open() on the session returned by createPlaidLinkSession(config). Move callbacks to the create call.";
-};
+);
 
 /**
  * @deprecated Removed in v13. Use `PlaidEmbeddedSearchView`.
  */
-export const EmbeddedLinkView = removedApi(
+export const EmbeddedLinkView = migrationDiagnostic(
   "EmbeddedLinkView",
   "Use PlaidEmbeddedSearchView.",
-) as unknown as {
-  readonly __migration_error__: "Removed in v13. Use PlaidEmbeddedSearchView.";
-};
+);
+
+/**
+ * @deprecated Removed in v13. Use `await createPlaidLinkSession(config)`, then
+ * call `await session.open()` on the returned session.
+ */
+export const openLink = migrationDiagnostic(
+  "openLink",
+  "Use await createPlaidLinkSession(config), then call await session.open() on the returned session.",
+);
+
+/**
+ * @deprecated Removed in v13. Pass `onEvent` to the create call instead of
+ * subscribing separately.
+ */
+export const usePlaidEmitter = migrationDiagnostic(
+  "usePlaidEmitter",
+  "Pass onEvent to createPlaidLinkSession(config) instead of subscribing separately.",
+);
+
+/**
+ * @deprecated Removed in v13. Call `await session.submit(data)` on the session
+ * returned by `createPlaidLayerSession(config)`.
+ */
+export const submit = migrationDiagnostic(
+  "submit",
+  "Call await session.submit(data) on the session returned by createPlaidLayerSession(config).",
+);
+
+/**
+ * @deprecated Removed in v13. Build your own button and call
+ * `await createPlaidLinkSession(config)`, then `await session.open()`.
+ */
+export const PlaidLink = migrationDiagnostic(
+  "PlaidLink",
+  "Build your own button and call await createPlaidLinkSession(config), then await session.open().",
+);
+
+/**
+ * @deprecated Removed in v13. Each create call resets session state, so no
+ * teardown call is needed.
+ */
+export const destroy = migrationDiagnostic(
+  "destroy",
+  "Remove the call. Each create call resets session state, so no teardown is needed.",
+);
+
+/**
+ * @deprecated Removed in v13 with no replacement.
+ */
+export const dismissLink = migrationDiagnostic(
+  "dismissLink",
+  "Remove the call. There is no programmatic dismiss API in v13.",
+);
 
 /** The React Native Plaid Link SDK version reported by the native module. */
 export const sdkVersion = NativePlaidModule.sdkVersion;


### PR DESCRIPTION
## Summary

Follow-up to #973. That PR made `create`, `open`, and `EmbeddedLinkView` report an actionable `TS2349` with the exact v13 replacement. The six other removed pre-v13 names did not get the treatment, so they still produce the original failure from the customer report:

```
error TS2614: Module '"react-native-plaid-link-sdk"' has no exported member 'usePlaidEmitter'.
  Did you mean to use 'import usePlaidEmitter from "react-native-plaid-link-sdk"' instead?
```

That suggestion is wrong for the same reason it was wrong for `create`, and `usePlaidEmitter` was named explicitly in the report. It appears in most pre-v13 tutorials, so it is a likely second line of agent-generated code.

## Changes

- **`usePlaidEmitter`, `openLink`, `submit`, `PlaidLink`, `destroy`, `dismissLink`** now carry migration diagnostics, bringing the covered set to all nine removed names.
- **Replacement text is single-sourced.** `migrationDiagnostic()` derives the compiler diagnostic from the runtime message via a template-literal return type, replacing the hand-duplicated string literal and `as unknown as` cast at each export. That duplication is how `usePlaidEmitter` was missed the first time — it was dropped from the AGENTS.md list while the code kept only three names.
- **The packed TypeScript guard covers all nine** and now asserts `TS2614` is absent outright. Previously the guard only checked three names, so a missing diagnostic export passed CI silently — which is exactly what happened.
- **Added a JSX fixture** to the guard. It only exercised the call form `EmbeddedLinkView({})`, but agents write `<EmbeddedLinkView />`. The element form works via `TS2786`; it was simply untested.
- AGENTS.md and README updated to list the full set and document the `TS2786` element-form error.

## Verification

Built the real tarball, installed it into a clean consumer, and ran `tsc`. All six previously-broken names now report their replacement, with zero occurrences of the bad default-import hint:

```
after.tsx(2,1): error TS2349: This expression is not callable.
  Type '{ readonly __migration_error__: "Removed in v13. Pass onEvent to createPlaidLinkSession(config) instead of subscribing separately."; }' has no call signatures.
after.tsx(5,1): error TS2349: This expression is not callable.
  Type '{ readonly __migration_error__: "Removed in v13. Use await createPlaidLinkSession(config), then call await session.open() on the returned session."; }' has no call signatures.
```

`PlaidLink` as JSX:

```
after-jsx.tsx(3,25): error TS2786: 'PlaidLink' cannot be used as a JSX component.
  Its type '{ readonly __migration_error__: "Removed in v13. Build your own button and call await createPlaidLinkSession(config), then await session.open()."; }' is not a valid JSX element type.
```

I also negative-tested the guard: deleting the `usePlaidEmitter` export makes it fail with all three assertions, including `a removed API has no migration diagnostic export; TypeScript reported TS2614 instead.` It passes again once restored.

## Test plan

- `npm run lint` — clean
- `npm test` — 135 passed (11 suites)
- `npm run build`
- `npm run check:package`
- `npm run check:typescript-api`

## Note

This does not ship anything on its own — #974 (13.1.0) is still open, and npm `latest` is 13.0.5 from 2026-08-28, which predates #971/#972/#973. Until a release goes out, users still hit the original failure for every name including `create`. Worth folding this into that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)